### PR TITLE
dev - Set Name Optimized

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,9 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
+# namingpath = r'B:\write\code\git\naming'
+# import sys
+# sys.path.append(namingpath)
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.doctest',
               'sphinx.ext.intersphinx',

--- a/naming/base.py
+++ b/naming/base.py
@@ -18,6 +18,8 @@ def _field_property(field_name: str) -> property:
         return self._values.get(field_name)
 
     def setter(self, value):
+        if value and str(value) == self._values.get(field_name):
+            return
         new_name = self.get_name(**{field_name: value})
         self.set_name(new_name)
     return property(getter, setter)
@@ -124,6 +126,7 @@ class _BaseName(metaclass=_ABCName):
 
         :param name: The name to be set on this object.
         :raises NameError: If an invalid string is provided.
+        :returns: Reference to self.
         """
         match = self.__regex.match(name)
         if not match:
@@ -132,6 +135,7 @@ class _BaseName(metaclass=_ABCName):
             raise NameError(msg)
         self.__set_name(name)
         self.__values.update(match.groupdict())
+        return self
 
     @property
     def _values(self) -> typing.Dict[str, str]:

--- a/naming/tests/__init__.py
+++ b/naming/tests/__init__.py
@@ -54,6 +54,8 @@ class TestEasyName(unittest.TestCase):
         pf = ProjectFile('this_is_my_base_name_2017_christianl_constant_iamlast.base.17.abc')
         self.assertEqual('this_is_my_base_name_2017_christianl_constant_iamlast', pf.nice_name)
         self.assertEqual('this_is_my_base_name_2017_christianl_constant_iamlast.base.17', pf.pipe_name)
+        # setting same fields should be returning early
+        pf.year = 2017
         self.assertEqual('2017', pf.year)
         self.assertEqual('iamlast', pf.lastfield)
         self.assertEqual('abc', pf.extension)

--- a/naming/tests/__init__.py
+++ b/naming/tests/__init__.py
@@ -29,6 +29,8 @@ class TestName(unittest.TestCase):
         n = Name()
         n.set_name('setname')
         self.assertEqual('setname', n.get_name())
+        self.assertEqual(n, n.set_name('setname'))
+        self.assertTrue(isinstance(n.set_name('setname'), n.__class__))
 
 
 class TestEasyName(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(
     url='https://github.com/chrizzFTD/naming',
     download_url='https://github.com/chrizzFTD/naming/releases/tag/0.1.3',
     classifiers=['Programming Language :: Python :: 3.6'],
-    extras_require={'docs': ['sphinx_autodoc_typehints']}
+    extras_require={'docs': ['sphinx_autodoc_typehints', 'sphinx_rtd_theme']}
 )


### PR DESCRIPTION
### Overview
- Added setting values optimization, returning self reference on set_name method.

### Details
*Changes:*
- If `field` has already the requested value, [not setting it](https://github.com/chrizzFTD/naming/compare/develop...feature/set_name_return_value?expand=1#diff-73cbd5dbbc5e0ea1dd4f58450af94f1aR21).
- `set_name` method now returns a [reference to self](https://github.com/chrizzFTD/naming/compare/develop...feature/set_name_return_value?expand=1#diff-73cbd5dbbc5e0ea1dd4f58450af94f1aR138).