### PR TITLE
Feature/base refactor nometa

### DIFF
--- a/docs/source/Name.rst
+++ b/docs/source/Name.rst
@@ -7,7 +7,6 @@ Name
 .. inheritance-diagram:: naming.Name
 
 .. autoclass:: naming.Name
-    :special-members: __init__
     :members:
     :inherited-members:
     :no-show-inheritance:

--- a/docs/source/Overview.rst
+++ b/docs/source/Overview.rst
@@ -139,10 +139,10 @@ Basic Use
         'project_data_name_2017_christianl_constant_iamlast'
         >>> pf.year
         '2017'
-        >>> pf.year = 'nondigits'  # mutating with invalid fields raises a NameError
+        >>> pf.year = 'nondigits'  # mutating with invalid fields raises a ValueError
         Traceback (most recent call last):
         ...
-        NameError: Can't set invalid name 'project_data_name_nondigits_christianl_constant_iamlast.data.17.abc' on ProjectFile instance. Valid convention is: '{base} {year} {user} {another} {last}.{pipe}.{suffix}' with pattern: (?P<base>\w+)_(?P<year>[0-9]{4})_(?P<user>[a-z]+)_(?P<another>(constant))_(?P<last>[a-zA-Z0-9]+)(?P<pipe>(\.(?P<output>\w+))?\.(?P<version>\d+)(\.(?P<frame>\d+))?)(\.(?P<suffix>\w+))'
+        ValueError: Can't set invalid name 'project_data_name_nondigits_christianl_constant_iamlast.data.17.abc' on ProjectFile instance. Valid convention is: '{base}_{year}_{user}_{another}_{last}.{pipe}.{suffix}' with pattern: ^(?P<base>\w+)_(?P<year>[0-9]{4})_(?P<user>[a-z]+)_(?P<another>(constant))_(?P<last>[a-zA-Z0-9]+)(?P<pipe>(\.(?P<output>\w+))?\.(?P<version>\d+)(\.(?P<frame>\d+))?)(\.(?P<suffix>\w+))$'
         >>> pf.year = 1907
         >>> pf
         ProjectFile("project_data_name_1907_christianl_constant_iamlast.data.17.abc")

--- a/docs/source/Overview.rst
+++ b/docs/source/Overview.rst
@@ -24,27 +24,44 @@ Basic Use
 
         >>> from naming import Name
         >>> n = Name()
-        >>> n.get_name()  # no name has been set on the object, convention is solved with [missing] fields
-        '[base]'
+        >>> n.get_name()  # no name has been set on the object, convention is solved with {missing} fields
+        '{base}'
         >>> n.values
         {}
-        >>> n.set_name('hello_world')
-        >>> n.values
-        {'base': 'hello_world'}
+        >>> n.name = 'hello_world'
+        >>> n
+        Name("hello_world")
         >>> str(n)  # cast to string
         'hello_world'
+        >>> n.values
+        {'base': 'hello_world'}
+        >>> # modify name and get values from field names
+        >>> n.base = 'through_field_name'
+        >>> n.values
+        {'base': 'through_field_name'}
+        >>> n.base
+        'through_field_name'
 
     Pipe::
 
         >>> from naming import Pipe
+        >>> p = Pipe()
+        >>> p.get_name()
+        '{base}.{pipe}'
+        >>> p.get_name(version=10)
+        '{base}.10'
+        >>> p.get_name(output='data')
+        '{base}.data.{version}'
+        >>> p.get_name(output='cache', version=7, frame=24)
+        '{base}.cache.7.24'
         >>> p = Pipe('my_wip_data.1')
         >>> p.version
         '1'
         >>> p.values
-        {'base': 'my_wip_data', 'version': '1'}
-        >>> p.get_name(output='exchange', version=2)  # returns a new string
-        'my_wip_data.exchange.2'
-        >>> p.name  # object didn't change
+        {'base': 'my_wip_data', 'pipe': '.1', 'version': '1'}
+        >>> p.get_name(output='exchange')  # returns a new string
+        'my_wip_data.exchange.1'
+        >>> p.name
         'my_wip_data.1'
         >>> p.output = 'exchange'  # mutates the object
         >>> p.name
@@ -54,31 +71,33 @@ Basic Use
         >>> p.name
         'my_wip_data.exchange.7.101'
         >>> p.values
-        {'base': 'my_wip_data', 'output': 'exchange', 'version': '7', 'frame': '101'}
+        {'base': 'my_wip_data', 'pipe': '.exchange.7.101', 'output': 'exchange', 'version': '7', 'frame': '101'}
 
     File::
 
         >>> from naming import File
         >>> f = File()
         >>> f.get_name()
-        '[basse].[extension]'
-        >>> f.get_name(extension='png')
-        '[base].png'
-        >>> f.set_name('hello.world')
+        '{basse}.{suffix}'
+        >>> f.get_name(suffix='png')
+        '{base}.png'
+        >>> f = File('hello.world')
         >>> f.values
-        {'base': 'hello', 'extension': 'world'}
-        >>> f.extension
+        {'base': 'hello', 'suffix': 'world'}
+        >>> f.suffix
         'world'
-        >>> f.extension = 'abc'
+        >>> f.suffix = 'abc'
         >>> f.name
         'hello.abc'
+        >>> f.path
+        WindowsPath('hello.abc')
 
     PipeFile::
 
         >>> from naming import PipeFile
         >>> p = PipeFile('wipfile.7.ext')
         >>> p.values
-        {'base': 'wipfile', 'version': '7', 'extension': 'ext'}
+        {'base': 'wipfile', 'pipe': '.7', 'version': '7', 'suffix': 'ext'}
         >>> [p.get_name(frame=x, output='render') for x in range(10)]
         ['wipfile.render.7.0.ext',
         'wipfile.render.7.1.ext',
@@ -105,32 +124,33 @@ Basic Use
         ...                   another='(constant)',
         ...                   last='[a-zA-Z0-9]+')
         ...
-        >>> pf = ProjectFile('project_data_name_2017_christianl_constant_iamlast.data.17.abc')
+        >>> pf = ProjectFile('project_data_name_2017_christianl_constant_iamlast.data.17.abc', sep='_')
         >>> pf.values
         {'base': 'project_data_name',
         'year': '2017',
         'user': 'christianl',
         'another': 'constant',
         'last': 'iamlast',
+        'pipe': '.data.17',
         'output': 'data',
         'version': '17',
-        'extension': 'abc'}
-        >>> pf.nice_name  # no pipe & extension fields
+        'suffix': 'abc'}
+        >>> pf.nice_name  # no pipe & suffix fields
         'project_data_name_2017_christianl_constant_iamlast'
         >>> pf.year
         '2017'
         >>> pf.year = 'nondigits'  # mutating with invalid fields raises a NameError
         Traceback (most recent call last):
         ...
-        NameError: Can't set invalid name 'project_data_name_nondigits_christianl_constant_iamlast.data.17.abc' on ProjectFile instance. Valid convention is: [base]_[year]_[user]_[another]_[last].[pipe].[extension]
+        NameError: Can't set invalid name 'project_data_name_nondigits_christianl_constant_iamlast.data.17.abc' on ProjectFile instance. Valid convention is: '{base} {year} {user} {another} {last}.{pipe}.{suffix}' with pattern: (?P<base>\w+)_(?P<year>[0-9]{4})_(?P<user>[a-z]+)_(?P<another>(constant))_(?P<last>[a-zA-Z0-9]+)(?P<pipe>(\.(?P<output>\w+))?\.(?P<version>\d+)(\.(?P<frame>\d+))?)(\.(?P<suffix>\w+))'
         >>> pf.year = 1907
-        >>> pf.name
-        'project_data_name_1907_christianl_constant_iamlast.data.17.abc'
-        >>> pf.extension
+        >>> pf
+        ProjectFile("project_data_name_1907_christianl_constant_iamlast.data.17.abc")
+        >>> pf.suffix
         'abc'
-        >>> pf.separator = '  '  # you can set the separator to a different set of characters
+        >>> pf.sep = '  '  # you can set the separator to a different set of characters
         >>> pf.name
-        'project_data_name  1907  christianl  constant  iamlast.data.17.abc'
+        'project_data_name   1907   christianl   constant   iamlast.data.17.abc'
 
     Dropping fields from bases::
 
@@ -141,12 +161,12 @@ Basic Use
         ...
         >>> d = Dropper()
         >>> d.get_name()
-        '[without]_[basename].[pipe].[extension]'
+        '{without}_{basename}.{pipe}.{suffix}'
         >>> # New subclasses will drop the 'base' field as well
         >>> Subdropper = type('Dropper', (Dropper,), dict(config=dict(subdrop='[\w]')))
         >>> s = Subdropper()
         >>> s.get_name()
-        '[without]_[basename]_[subdrop].[pipe].[extension]'
+        '{without}_{basename}_{subdrop}.{pipe}.{suffix}'
 
     Setting compound fields::
 
@@ -158,10 +178,10 @@ Basic Use
         ...
         >>> c = Compound()
         >>> c.get_name()  # we see the original field 'base'
-        '[base].[pipe].[extension]'
+        '{base}.{pipe}.{suffix}'
         >>> c.get_name(first=50, second='abc')  # providing the compounds will work
-        '50abc.[pipe].[extension]'
-        >>> c.set_name(c.get_name(base='101dalmatians', version=1, extension='png'))  # providing the key field will also work
+        '50abc.{pipe}.{suffix}'
+        >>> c.name = c.get_name(base='101dalmatians', version=1, suffix='png')  # providing the key field will also work
         >>> c.nice_name
         '101dalmatians'
         >>> c.get_name(first=200)
@@ -178,23 +198,10 @@ Basic Use
         ...
         >>> fp = FilePath()
         >>> fp.get_name()
-        '[base]_[extrafield].[extension]'
+        '{base} {extrafield}.{suffix}'
         >>> # path attribute will vary depending on the OS
         >>> fp.path
-        WindowsPath('[base]/[extrafield]/[base]_[extrafield].[extension]')
-        >>> # File names have a cwd attribute that helps locate it on the file system. defaults to None
-        >>> print(fp.cwd)
-        None
-        >>> # full_path joins the cwd of the File object with the path attribute
-        >>> # if cwd is None, the full_path will resolve to the users home directory
-        >>> f.full_path
-        WindowsPath('C:/Users/Christian/[base]/[extrafield]/[base]_[extrafield].[extension]')
-        >>> f.cwd = 'A:/tempdir'
-        >>> f.full_path
-        WindowsPath('A:/tempdir/[base]/[extrafield]/[base]_[extrafield].[extension]')
-        >>> f.set_name('wip_file.abc')
-        >>> f.full_path
-        WindowsPath('A:/tempdir/wip/file/wip_file.abc')
+        WindowsPath('{base}/{extrafield}/{base} {extrafield}.{suffix}')
 
     Using properties as fields while solving names::
 
@@ -222,9 +229,14 @@ Basic Use
         ...
         >>> pf = PropertyField()
         >>> pf.get_name()
-        '[base]_[extrafield]_[nameproperty].[pipe].[extension]'
-        >>> pf.set_name('simple_props_staticvalue.1.abc')
+        '{base} {extrafield} staticvalue.{pipe}.{suffix}'
+        >>> pf.name = 'simple props staticvalue.1.abc'
         >>> pf.values
-        {'base': 'simple', 'extrafield': 'props', 'version': '1', 'extension': 'abc'}
+        {'base': 'simple',
+        'extrafield': 'props',
+        'nameproperty': 'staticvalue',
+        'pipe': '.1',
+        'version': '1',
+        'suffix': 'abc'}
         >>> pf.path
-        WindowsPath('simple/props/path_field/simple_props_staticvalue.1.abc')
+        WindowsPath('simple/props/path_field/simple props staticvalue.1.abc')

--- a/naming/__init__.py
+++ b/naming/__init__.py
@@ -81,9 +81,9 @@ class File(Name):
     @property
     def _pattern(self):
         sep = '\.'
-        pcfg = {k: self.cast(v, k) for k, v in self.file_config.items()}
-        pipe_pattern = r'(\.{suffix})'.format(sep=sep, **pcfg)
-        return rf'{super()._pattern}{pipe_pattern}'
+        casted = self.cast_config(self.file_config)
+        pat = r'(\.{suffix})'.format(sep=sep, **casted)
+        return rf'{super()._pattern}{pat}'
 
     def get_name(self, **values) -> str:
         if not values and self.name:
@@ -173,9 +173,9 @@ class Pipe(Name):
     @property
     def _pattern(self):
         sep = rf'\{self.pipe_separator}'
-        pcfg = {k: self.cast(v, k) for k, v in self.pipe_config.items()}
-        pipe_pattern = r'(?P<pipe>({sep}{output})?{sep}{version}({sep}{frame})?)'.format(sep=sep, **pcfg)
-        return rf'{super()._pattern}{pipe_pattern}'
+        casted = self.cast_config(self.pipe_config)
+        pat = r'(?P<pipe>({sep}{output})?{sep}{version}({sep}{frame})?)'.format(sep=sep, **casted)
+        return rf'{super()._pattern}{pat}'
 
     @property
     def pipe_separator(self) -> str:

--- a/naming/__init__.py
+++ b/naming/__init__.py
@@ -14,7 +14,7 @@ class Name(_BaseName):
     where pattern is a valid regular expression.
 
     Classes may as well have a `drops` iterable attribute representing the fileds they want to ignore from their bases
-    and a `compounds` dictionary attribute for nesting existing fields into multiple new ones.
+    and a `compounds` dictionary attribute for nesting existing fields into new ones (or to override other fields).
 
     All fields should be unique. No duplicates are allowed.
 

--- a/naming/__init__.py
+++ b/naming/__init__.py
@@ -87,7 +87,7 @@ class File(Name):
 
     def get_name(self, **values) -> str:
         if not values and self.name:
-            return super().get_name(**values)
+            return super().get_name()
         suffix = values.get('suffix') or self.suffix or '{suffix}'
         return rf'{super().get_name(**values)}.{suffix}'
 
@@ -205,7 +205,7 @@ class Pipe(Name):
 
     def get_name(self, **values) -> str:
         if not values and self.name:
-            return super().get_name(**values)
+            return super().get_name()
         try:
             # allow for getting name without pipe field in subclasses
             pipe = values['pipe'] or ''

--- a/naming/__init__.py
+++ b/naming/__init__.py
@@ -250,10 +250,10 @@ class PipeFile(File, Pipe):
         'project_data_name_2017_christianl_constant_iamlast'
         >>> pf.year
         '2017'
-        >>> pf.year = 'nondigits'  # mutating with invalid fields raises a NameError
+        >>> pf.year = 'nondigits'  # mutating with invalid fields raises a ValueError
         Traceback (most recent call last):
         ...
-        NameError: Can't set invalid name 'project_data_name_nondigits_christianl_constant_iamlast.data.17.abc' on ProjectFile instance. Valid convention is: '{base} {year} {user} {another} {last}.{pipe}.{suffix}' with pattern: (?P<base>\w+)_(?P<year>[0-9]{4})_(?P<user>[a-z]+)_(?P<another>(constant))_(?P<last>[a-zA-Z0-9]+)(?P<pipe>(\.(?P<output>\w+))?\.(?P<version>\d+)(\.(?P<frame>\d+))?)(\.(?P<suffix>\w+))'
+        ValueError: Can't set invalid name 'project_data_name_nondigits_christianl_constant_iamlast.data.17.abc' on ProjectFile instance. Valid convention is: '{base}_{year}_{user}_{another}_{last}.{pipe}.{suffix}' with pattern: ^(?P<base>\w+)_(?P<year>[0-9]{4})_(?P<user>[a-z]+)_(?P<another>(constant))_(?P<last>[a-zA-Z0-9]+)(?P<pipe>(\.(?P<output>\w+))?\.(?P<version>\d+)(\.(?P<frame>\d+))?)(\.(?P<suffix>\w+))$'
         >>> pf.year = 1907
         >>> pf
         ProjectFile("project_data_name_1907_christianl_constant_iamlast.data.17.abc")

--- a/naming/__init__.py
+++ b/naming/__init__.py
@@ -12,7 +12,7 @@ class Name(_BaseName):
     Base class for name objects.
 
     Each subclass may have its own `config` attribute that should be a dictionary in the form of {field: pattern}
-    where pattern is a valid regular expression.
+    where `pattern` is a valid regular expression.
 
     Classes may as well have a `drops` iterable attribute representing the fileds they want to ignore from their bases
     and a `compounds` dictionary attribute for nesting existing fields into new ones (or to override other fields).
@@ -22,7 +22,7 @@ class Name(_BaseName):
     ======  ==========
     **Config:**
     ------------------
-    *base*  Accepts any amount of word characters ([a-zA-Z0-9_])
+    *base*  Accepts any amount of word characters [a-zA-Z0-9_]
     ======  ==========
 
     Basic use::
@@ -36,6 +36,8 @@ class Name(_BaseName):
         >>> n.name = 'hello_world'
         >>> n
         Name("hello_world")
+        >>> str(n)  # cast to string
+        'hello_world'
         >>> n.values
         {'base': 'hello_world'}
         >>> # modify name and get values from field names
@@ -77,19 +79,8 @@ class File(Name):
         'hello.abc'
         >>> f.path
         WindowsPath('hello.abc')
-        >>> f.cwd  # if not passed when initialised, defaults to current user's home directory
-        WindowsPath('C:/Users/Christian')
-        >>> f.fullpath
-        WindowsPath('C:/Users/Christian/hello.abc')
-        >>> f = File(cwd='some/path')
-        >>> f.fullpath
-        WindowsPath('some/path/{base}.{suffix}')
     """
     file_config = NameConfig(dict(suffix='\w+'))
-
-    def __init__(self, *args, cwd=None, **kwargs):
-        self.cwd = cwd
-        super().__init__(*args, **kwargs)
 
     @property
     def _pattern(self) -> str:
@@ -105,29 +96,15 @@ class File(Name):
         return rf'{super().get_name(**values)}.{suffix}'
 
     def get_path_pattern_list(self) -> list:
-        """Fields / properties names (sorted) to concatenate and use when solving `path` and `fullpath` attributes"""
+        """Fields / properties names (sorted) to be used when solving `path`"""
         return []
 
     @property
-    def cwd(self) -> Path:
-        """Path used as the current working directory when solving the `fullpath` attribute. Defaults to Path.home()"""
-        return self._cwd
-
-    @cwd.setter
-    def cwd(self, value: str):
-        self._cwd = Path(value or Path.home())
-
-    @property
     def path(self) -> Path:
-        """The Path representing this object on the filesystem."""
+        """The Path representing this file name object."""
         args = list(self._iter_translated_field_names(self.get_path_pattern_list()))
         args.append(self.get_name())
         return Path(*args)
-
-    @property
-    def fullpath(self) -> Path:
-        """The resolved full Path representing this object on the filesystem."""
-        return Path.joinpath(self.cwd, self.path)
 
 
 class Pipe(Name):
@@ -147,7 +124,7 @@ class Pipe(Name):
     ======  ============
     **Composed Fields:**
     --------------------
-    *pipe*  Combination of unique fields in the form of: .{output})\*.{version}.{frame}**
+    *pipe*  Combination of unique fields in the form of: (.{output})\*.{version}.{frame}**
     \* optional field. ** exists only when *output* is there as well.
     ====================
 

--- a/naming/__init__.py
+++ b/naming/__init__.py
@@ -86,7 +86,7 @@ class File(Name):
     def _pattern(self) -> str:
         sep = re.escape('.')
         casted = self.cast_config(self.file_config)
-        pat = r'(\.{suffix})'.format(sep=sep, **casted)
+        pat = r'({sep}{suffix})'.format(sep=sep, **casted)
         return rf'{super()._pattern}{pat}'
 
     def get_name(self, **values) -> str:
@@ -101,7 +101,7 @@ class File(Name):
 
     @property
     def path(self) -> Path:
-        """The Path representing this file name object."""
+        """A Path for this name object joining field names from `self.get_path_pattern_list` with this object's name"""
         args = list(self._iter_translated_field_names(self.get_path_pattern_list()))
         args.append(self.get_name())
         return Path(*args)

--- a/naming/base.py
+++ b/naming/base.py
@@ -1,76 +1,101 @@
 import re
-import abc
 import typing
+from collections import ChainMap
+from types import MappingProxyType
 
 
-def _regex_property(field_name: str) -> property:
-    def getter(self):
-        pattern = getattr(self, rf'__{field_name}')
-        return rf'(?P<{field_name}>{pattern})'
-
-    def setter(self, value):
-        setattr(self, rf'__{field_name}', value)
-    return property(getter, setter)
+def dct_from_mro(cls, attr_name):
+    # TODO: replace with collections.ChainMap on py37+
+    d = {}
+    for mapping in filter(None, (getattr(c, attr_name, None) for c in reversed(cls.mro()))):
+        d.update(mapping)
+    return d
 
 
-def _field_property(field_name: str) -> property:
-    def getter(self):
-        return self._values.get(field_name)
+class NameConfig:
+    def __init__(self, cfg=None):
+        if not isinstance(cfg, MappingProxyType):
+            cfg = MappingProxyType(cfg or {})
+        self.cfg = cfg
 
-    def setter(self, value):
-        if value and str(value) == self._values.get(field_name):
+    def __get__(self, obj, objtype):
+        cfg = self.cfg
+        if obj is None:
+            return cfg
+
+        result = {}
+        cmps = objtype.compounds
+        cmps_fields = set().union(*(v for v in cmps.values()))
+
+        # solve compound fields
+        to_solve = set(cmps).intersection(cfg)
+        solved = dict()
+        while to_solve:
+            for ck, cvs in cmps.items():
+                if ck in solved or ck not in to_solve:  # don't solve keys that are not in cfg map
+                    continue
+                if (to_solve - {ck}).intersection(cvs):  # there are other fields left to solve before this one
+                    continue
+                solved[ck] = ''.join(obj.cast(solved.pop(cv, cfg[cv]), cv, cv != ck) for cv in cvs)
+                to_solve.remove(ck)
+
+        for k, v in cfg.items():
+            if k in cmps and k in solved:  # a compound may be nested. ensure it's also in the solved dict
+                result[k] = solved[k]
+            elif k in cmps_fields:
+                continue
+            else:
+                result[k] = v
+        return result
+
+    def __set__(self, obj, val):
+        raise AttributeError("Can't set read-only attribute")
+
+
+class FieldValue:
+    def __init__(self, name='var'):
+        self.name = name
+
+    def __get__(self, obj, objtype):
+        return obj._values.get(self.name)
+
+    def __set__(self, obj, val):
+        if val and str(val) == obj._values.get(self.name):
             return
-        new_name = self.get_name(**{field_name: value})
-        self.set_name(new_name)
-    return property(getter, setter)
+        new_name = obj.get_name(**{self.name: val})
+        obj.name = new_name
 
 
-class _ABCName(abc.ABCMeta):
-    def __new__(mcs, name, bases, args):
-        new_cls = super().__new__(mcs, name, bases, args)
-        mcs._merge_bases_dict('config', new_cls, bases)
-        mcs._merge_bases_dict('compounds', new_cls, bases)
-        new_cls._compounds_fields = set().union(*[v for v in new_cls.compounds.values()])
-        mcs._merge_bases_drops(new_cls, bases)
-        return new_cls
-
-    @staticmethod
-    def _merge_bases_dict(name, new_cls, bases):
-        base_maps = [getattr(b, name, {}) for b in bases]
-        base_maps.append(getattr(new_cls, name, {}))
-        new_map = {}
-        for dic in base_maps:
-            new_map.update(dic)
-        setattr(new_cls, name, new_map)
-
-    @staticmethod
-    def _merge_bases_drops(new_cls, bases):
-        new_drops = set(getattr(new_cls, 'drops', tuple()))
-        for b in bases:
-            for drop in getattr(b, 'drops', tuple()):
-                new_drops.add(drop)
-                new_cls.config.pop(drop, None)
-        new_cls.drops = new_drops
-
-
-class _BaseName(metaclass=_ABCName):
+class _BaseName:
     """This is the base abstract class for Name objects. You should not need to subclass directly from this object.
     All subclasses are encouraged to inherit from Name instead of this one."""
+    config = dict()
+    compounds = dict()
+    drops = tuple()
 
-    _regex_property_name = re.compile(r'[a-zA-Z]\w+')
+    def __init_subclass__(cls, **kwargs):
+        cls.drops = set().union(*(getattr(c, 'drops', tuple()) for c in cls.mro()))
+        setattr(cls, 'compounds', MappingProxyType(dct_from_mro(cls, 'compounds')))
 
-    def __init__(self, name: str='', separator: str='_'):
+        cfg = dct_from_mro(cls, 'config')
+        for drop in cls.drops:
+            cfg.pop(drop, None)
+            setattr(cls, drop, None)
+
+        for k in ChainMap(cfg, *(vv.cfg for vv in vars(cls).values() if isinstance(vv, NameConfig))):
+            setattr(cls, k, FieldValue(k))
+        setattr(cls, 'config', NameConfig(MappingProxyType(cfg)))
+
+    def __init__(self, name: str = '', sep: str = ' '):
         super().__init__()
-        self.__values = {}
-        self.__items = self.__values.items()
-        self._set_separator(separator)
-        self._set_patterns()
+        self._values = {}
+        self._items = self._values.items()
+        self._set_separator(sep)
         self._init_name_core(name)
 
-    def _init_name_core(self, name: str):
+    def _init_name_core(self, name):
         """Runs whenever a Name object is initialized or its name is set."""
-        self.__set_name(name)
-        self._set_values()
+        self._name = rf'{name}' if name else ''
         self.__set_regex()
         self.__validate()
 
@@ -79,49 +104,22 @@ class _BaseName(metaclass=_ABCName):
         self._separator_pattern = rf'\{separator}'
 
     @property
-    def separator(self) -> str:
+    def sep(self) -> str:
         """The string that acts as a separator of all the fields in the name."""
         return self._separator
 
-    @separator.setter
-    def separator(self, value: str):
+    @sep.setter
+    def sep(self, value: str):
         self._set_separator(value)
         name = self.get_name(**self.values) if self.name else None
         self._init_name_core(name)
 
-    @abc.abstractmethod
-    def _set_patterns(self):
-        pass
-
-    def _set_pattern(self, *patterns):
-        for p in patterns:
-            setattr(self.__class__, rf'_{p}', _regex_property(p))
-            self._add_field_property(p)
-
-    def _add_field_property(self, field_name):
-        setattr(self.__class__, field_name, _field_property(field_name))
-
-    def __set_name(self, name: str):
-        self.__name = rf'{name}' if name else None
-
     @property
-    def name(self) -> str:
-        """The name string set on the object."""
-        return self.__name
+    def name(self):
+        return self._name
 
-    @abc.abstractmethod
-    def _set_values(self):
-        pass
-
-    def __set_regex(self):
-        self.__regex = re.compile(r'^{}$'.format(self._get_joined_pattern()))
-
-    def __validate(self):
-        if not self.name:
-            return
-        self.set_name(self.name)
-
-    def set_name(self, name: str):
+    @name.setter
+    def name(self, name: str):
         """Set this object's name to the provided string.
 
         :param name: The name to be set on this object.
@@ -130,31 +128,34 @@ class _BaseName(metaclass=_ABCName):
         """
         match = self.__regex.match(name)
         if not match:
-            msg = ' '.join([rf"Can't set invalid name '{name}' on {self.__class__.__name__} instance.",
-                            rf"Valid convention is: {self.__class__().get_name()}"])
+            cls = self.__class__
+            msg = ' '.join([rf"Can't set invalid name '{name}' on {cls.__name__} instance.",
+                            rf"Valid convention is: '{cls().get_name()}' with pattern: {self._pattern}'"])
             raise NameError(msg)
-        self.__set_name(name)
-        self.__values.update(match.groupdict())
-        return self
+
+        self._name = rf'{name}'
+        self._values.update(match.groupdict())
+
+    def __set_regex(self):
+        self.__regex = re.compile(rf'^{self._pattern}$')
 
     @property
-    def _values(self) -> typing.Dict[str, str]:
-        return self.__values
+    def _pattern(self):
+        pairs = (self.cast(self.config.get(p, getattr(self, p)), p) for p in self.get_pattern_list())
+        return self._separator_pattern.join(pairs)
 
-    @abc.abstractmethod
+    def __validate(self):
+        if not self._name:
+            return
+        self.name = self._name
+
     def get_pattern_list(self) -> typing.List[str]:
-        return []
-
-    def _get_values_pattern(self) -> typing.List[str]:
-        return [getattr(self, p) for p in self.get_pattern_list()]
-
-    def _get_joined_pattern(self) -> str:
-        return self._separator_pattern.join(self._get_values_pattern())
+        return list(self.config)
 
     @property
     def values(self) -> dict:
         """The field values of this object's name as a dictionary in the form of {field: value}."""
-        return {k: v for k, v in self.__items if not self._filter_kv(k, v)}
+        return {k: v for k, v in self._items if not self._filter_kv(k, v)}
 
     def _filter_kv(self, k: str, v) -> bool:
         if self._filter_k(k) or self._filter_v(v):
@@ -183,32 +184,36 @@ class _BaseName(metaclass=_ABCName):
         if not values and self.name:
             return self.name
         if values:
-            for ck, cv in getattr(self, 'compounds', {}).items():
-                if ck not in values:
-                    compounds = []
-                    for c in cv:
-                        value = values.get(c) or getattr(self, c)
-                        if value is None:  # 0 is a valid value
-                            break
-                        compounds.append(rf'{value}')
+            # if values are provided, solve compounds that may be affected
+            cmps = self.compounds
+            to_solve = set(cmps)
+            solved = dict()
+            while to_solve:
+                for ck, cvs in cmps.items():
+                    if ck in solved or ck not in to_solve:
+                        continue
+                    elif (to_solve - {ck}).intersection(cvs):  # there are other fields left to solve before this one
+                        continue
+                    if values.get(ck):
+                        solved[ck] = rf'{values.pop(ck)}'
                     else:
-                        values[ck] = ''.join(compounds)
+                        gen = [solved.pop(cv, values.get(cv) or getattr(self, cv)) for cv in cvs]
+                        if None not in gen:
+                            solved[ck] = ''.join(rf'{v}' for v in gen)
+                    to_solve.remove(ck)
+            values.update(solved)
         return self._get_nice_name(**values)
 
     def _iter_translated_pattern_list(self, pattern: str, **values) -> typing.Generator:
-        self_values = self._values
-        for p in getattr(self, pattern)():
-            nice_name = self._regex_property_name.search(p).group(0)
-            if nice_name in values:
-                value = str(values[nice_name])
-            elif self_values:
-                try:
-                    value = str(self_values[nice_name])
-                except KeyError:
-                    value = getattr(self, p)  # must be a valid property
+        for field_name in getattr(self, pattern)():
+            if field_name in values:
+                yield rf'{values[field_name]}'
             else:
-                value = rf'[{nice_name}]'
-            yield value
+                yield getattr(self, field_name) or rf'{{{field_name}}}'
+
+    @staticmethod
+    def cast(value, name, named=True):
+        return rf'(?P<{name}>{value})' if named else rf'{value}'
 
     def __str__(self):
         return self.get_name()

--- a/naming/base.py
+++ b/naming/base.py
@@ -122,10 +122,10 @@ class _BaseName:
 
     def __init__(self, name: str = '', sep: str = ' '):
         super().__init__()
-        self._uc = MappingProxyType({})  # unreferenced compounds
         self._name = ''
         self._values = {}
         self._items = self._values.items()
+        self._uc = MappingProxyType({})  # unreferenced compounds
         self._set_separator(sep)
         self._init_name_core(name)
 

--- a/naming/base.py
+++ b/naming/base.py
@@ -158,15 +158,17 @@ class _BaseName:
         """Set this object's name to the provided string.
 
         :param name: The name to be set on this object.
-        :raises NameError: If an invalid string is provided.
+        :raises ValueError: If an invalid string is provided.
         """
         name = rf'{name}' if name else ''
         if name:
             match = self.__regex.match(name)
             if not match:
+                proxy = self.__class__(sep=self._separator)
+                pat = self.__regex.pattern
                 msg = (rf"Can't set invalid name '{name}' on {self.__class__.__name__} instance. "
-                       rf"Valid convention is: '{self.__class__().get_name()}' with pattern: {self._pattern}'")
-                raise NameError(msg)
+                       rf"Valid convention is: '{proxy.get_name()}' with pattern: {pat}'")
+                raise ValueError(msg)
             self._values.update(match.groupdict())
         else:
             self._values.clear()

--- a/naming/base.py
+++ b/naming/base.py
@@ -12,7 +12,7 @@ def _dct_from_mro(cls: type, attr_name: str) -> dict:
 
 
 def _sorted_items(mapping: typing.Mapping) -> typing.Generator:
-    """Given a mapping where values are iterables, iterate over the values whose contained references are not used as
+    """Given a mapping where values are iterables, yield items whose values contained references are not used as
     keys first:
 
     Example:
@@ -25,13 +25,13 @@ def _sorted_items(mapping: typing.Mapping) -> typing.Generator:
         one ('hi', 'six', 'net')
         two ('two', 'one', 'foo')
     """
-    to_solve = set(mapping)
-    while to_solve:
+    to_yield = set(mapping)
+    while to_yield:
         for key, values in mapping.items():
-            if key not in to_solve or (to_solve - {key} & set(values)):  # other fields left to solve before this one
+            if key not in to_yield or (to_yield - {key} & set(values)):  # other keys left to yield before this one
                 continue
             yield key, values
-            to_solve.remove(key)
+            to_yield.remove(key)
 
 
 class NameConfig:

--- a/naming/base.py
+++ b/naming/base.py
@@ -238,5 +238,4 @@ class _BaseName:
         return self.get_name()
 
     def __repr__(self):
-        name = self.name or ''
-        return rf'{self.__class__.__name__}("{name}")'
+        return rf'{self.__class__.__name__}("{self.name}")'

--- a/naming/base.py
+++ b/naming/base.py
@@ -57,7 +57,7 @@ class NameConfig:
         cmps_fields = set().union(*(v for v in cmps.values()))
 
         # solve compound fields
-        solved = dict()
+        solved = dict()  # will not preserve order
         for ck, cvs in _sorted_items(cmps):
             solved[ck] = ''.join(obj.cast(solved.pop(cv, cfg[cv]), cv, cv != ck) for cv in cvs)
 
@@ -222,6 +222,10 @@ class _BaseName:
     @staticmethod
     def cast(value, name, named=True):
         return rf'(?P<{name}>{value})' if named else rf'{value}'
+
+    @classmethod
+    def cast_config(cls, config):
+        return {k: cls.cast(v, k) for k, v in config.items()}
 
     def __str__(self):
         return self.get_name()

--- a/naming/base.py
+++ b/naming/base.py
@@ -177,14 +177,15 @@ class _BaseName:
         cfg = self.config
         # look for pattern in `cfg` first; then in `self` and finally in unreferenced solved compounds
         pattern_list = self.get_pattern_list()
-        if not pattern_list:
-            msg = ('Expected iterable containing strings with field names from `get_pattern_list`. '
+        if not pattern_list or not isinstance(pattern_list, (list, tuple)):
+            msg = ('Expected list / tuple containing strings with field names from `get_pattern_list`. '
                    'Got: {} instead'.format(pattern_list))
             raise ValueError(msg)
         casted = (self.cast(cfg.get(p, getattr(self, p) or self._uc.get(p)), p) for p in self.get_pattern_list())
         return self._separator_pattern.join(casted)
 
     def get_pattern_list(self) -> typing.List[str]:
+        """Fields / properties names (sorted) to be used when building names. Defaults to the keys of self.config"""
         return list(self.config)
 
     @property
@@ -204,7 +205,7 @@ class _BaseName:
         """Get a new name string from this object's name values.
 
         :param values: Variable keyword arguments where the **key** should refer to a field on this object that will
-                       use the provided value to build the new name.
+                       use the provided **value** to build the new name.
         """
         if not values and self.name:
             return self.name

--- a/naming/base.py
+++ b/naming/base.py
@@ -130,7 +130,7 @@ class _BaseName:
         self._init_name_core(name)
 
     def _init_name_core(self, name: str):
-        """Runs whenever a Name object is initialized or its name is set."""
+        """Runs whenever a new instance is initialized or `sep` is set."""
         self.__regex = re.compile(rf'^{self._pattern}$')
         self.name = name
 

--- a/naming/tests/__init__.py
+++ b/naming/tests/__init__.py
@@ -249,6 +249,28 @@ class TestCompound(unittest.TestCase):
             c.values)
         self.assertEqual('200dalmatians.1.png', c.get_name(first=200))
 
+        class CompUnused(Name):
+            config = dict(first='1',
+                          second='2')
+            compounds = dict(cmp=('first', 'second'))
+
+        class CompUsed(CompUnused):
+            def get_pattern_list(self):
+                return ['cmp'] + super().get_pattern_list()
+
+        c = CompUnused()
+        self.assertEqual('{base}', c.get_name())
+        c.name = 'hello_world'
+        self.assertEqual(None, c.cmp)
+        self.assertEqual({'base': 'hello_world'}, c.values)
+
+        c = CompUsed()
+        self.assertEqual('{cmp} {base}', c.get_name())
+        self.assertEqual(None, c.cmp)
+        c.name = '12 hello_world'
+        self.assertEqual('12', c.cmp)
+        self.assertEqual({'base': 'hello_world', 'cmp': '12', 'first': '1', 'second': '2'}, c.values)
+
 
 class TestPropertyField(unittest.TestCase):
 

--- a/naming/tests/__init__.py
+++ b/naming/tests/__init__.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from pathlib import Path
 
@@ -154,12 +153,6 @@ class TestFile(unittest.TestCase):
         self.assertEqual('ext', f.suffix)
         self.assertEqual('myfile', f.base)
         self.assertEqual(f.get_name(), str(f.path))
-        self.assertEqual(os.path.join(Path.home(), f.get_name()), str(f.fullpath))
-
-    def test_cwd(self):
-        f = File()
-        f.cwd = 'some/absolute/path'
-        self.assertEqual(os.path.join('some', 'absolute', 'path', f.get_name()), str(f.fullpath))
 
 
 class TestPipeFile(unittest.TestCase):

--- a/naming/tests/__init__.py
+++ b/naming/tests/__init__.py
@@ -146,12 +146,12 @@ class TestFile(unittest.TestCase):
 
     def test_empty_name(self):
         f = File()
-        self.assertEqual('{base}.{extension}', f.get_name())
-        self.assertEqual('{base}.abc', f.get_name(extension='abc'))
-        self.assertEqual('{base}.{extension}', f.get_name(extension=''))
+        self.assertEqual('{base}.{suffix}', f.get_name())
+        self.assertEqual('{base}.abc', f.get_name(suffix='abc'))
+        self.assertEqual('{base}.{suffix}', f.get_name(suffix=''))
 
         f.name = 'myfile.ext'
-        self.assertEqual('ext', f.extension)
+        self.assertEqual('ext', f.suffix)
         self.assertEqual('myfile', f.base)
         self.assertEqual(f.get_name(), str(f.path))
         self.assertEqual(os.path.join(Path.home(), f.get_name()), str(f.full_path))
@@ -166,11 +166,11 @@ class TestPipeFile(unittest.TestCase):
 
     def test_empty_name(self):
         f = PipeFile()
-        self.assertEqual('{base}.{pipe}.{extension}', f.get_name())
-        self.assertEqual('{base}.{pipe}.abc', f.get_name(extension='abc'))
-        self.assertEqual('{base}.{pipe}.{extension}', f.get_name(extension=''))
+        self.assertEqual('{base}.{pipe}.{suffix}', f.get_name())
+        self.assertEqual('{base}.{pipe}.abc', f.get_name(suffix='abc'))
+        self.assertEqual('{base}.{pipe}.{suffix}', f.get_name(suffix=''))
         f.name = 'myfile.data.0.ext'
-        self.assertEqual('ext', f.extension)
+        self.assertEqual('ext', f.suffix)
         self.assertEqual('myfile', f.base)
         self.assertEqual('.data.0', f.pipe)
         self.assertEqual('0', f.version)
@@ -178,17 +178,17 @@ class TestPipeFile(unittest.TestCase):
 
     def test_set_property(self):
         pf = PipeFile()
-        self.assertEqual('{base}.{pipe}.{extension}', pf.get_name())
+        self.assertEqual('{base}.{pipe}.{suffix}', pf.get_name())
         with self.assertRaises(NameError):
             pf.name = 'awesome'
         pf.name = 'hello_world.1.png'
         pf.base = 'awesome'
         self.assertEqual('awesome', pf.nice_name)
-        self.assertEqual({'base': 'awesome', 'version': '1', 'pipe': '.1', 'extension': 'png'}, pf.values)
+        self.assertEqual({'base': 'awesome', 'version': '1', 'pipe': '.1', 'suffix': 'png'}, pf.values)
 
         p = PipeFile('my_pipe_file.1.png')
-        self.assertEqual({'base': 'my_pipe_file', 'version': '1', 'extension': 'png', 'pipe': '.1'}, p.values)
-        p.extension = 'abc'
+        self.assertEqual({'base': 'my_pipe_file', 'version': '1', 'suffix': 'png', 'pipe': '.1'}, p.values)
+        p.suffix = 'abc'
         self.assertEqual('my_pipe_file.1.abc', p.name)
         p.output = 'geometry'
         self.assertEqual('my_pipe_file.geometry.1.abc', p.name)
@@ -210,7 +210,7 @@ class TestPipeFile(unittest.TestCase):
         pf.year = 2017
         self.assertEqual('2017', pf.year)
         self.assertEqual('iamlast', pf.lastfield)
-        self.assertEqual('abc', pf.extension)
+        self.assertEqual('abc', pf.suffix)
 
 
 class TestDrops(unittest.TestCase):
@@ -219,16 +219,16 @@ class TestDrops(unittest.TestCase):
         Dropper = type('Dropper', (PipeFile,), dict(config=dict(without=r'[a-zA-Z0-9]+', basename=r'[a-zA-Z0-9]+'),
                                                     drops=('base',)))
         d = Dropper(sep='_')
-        self.assertEqual('{without}_{basename}.{pipe}.{extension}', d.get_name())
-        self.assertEqual('awesome_{basename}.{pipe}.{extension}', d.get_name(without='awesome'))
-        self.assertEqual('{without}_replaced.{output}.{version}.101.{extension}',
+        self.assertEqual('{without}_{basename}.{pipe}.{suffix}', d.get_name())
+        self.assertEqual('awesome_{basename}.{pipe}.{suffix}', d.get_name(without='awesome'))
+        self.assertEqual('{without}_replaced.{output}.{version}.101.{suffix}',
                          d.get_name(basename='replaced', frame=101))
 
         Subdropper = type('Dropper', (Dropper,), dict(config=dict(subdrop='[\w]')))
         s = Subdropper(sep='_')
-        self.assertEqual('{without}_{basename}_{subdrop}.{pipe}.{extension}', s.get_name())
-        self.assertEqual('awesome_{basename}_{subdrop}.{pipe}.{extension}', s.get_name(without='awesome'))
-        self.assertEqual('{without}_replaced_{subdrop}.{output}.{version}.101.{extension}',
+        self.assertEqual('{without}_{basename}_{subdrop}.{pipe}.{suffix}', s.get_name())
+        self.assertEqual('awesome_{basename}_{subdrop}.{pipe}.{suffix}', s.get_name(without='awesome'))
+        self.assertEqual('{without}_replaced_{subdrop}.{output}.{version}.101.{suffix}',
                          s.get_name(basename='replaced', frame=101))
 
 
@@ -238,13 +238,13 @@ class TestCompound(unittest.TestCase):
         Compound = type('Compound', (PipeFile,), dict(config=dict(first=r'[\d]+', second=r'[a-zA-Z]+'),
                                                       compounds=dict(base=('first', 'second'))))
         c = Compound(sep='_')
-        self.assertEqual('{base}.{pipe}.{extension}', c.get_name())
-        self.assertEqual('{base}.{pipe}.{extension}', c.get_name(first=50))
-        self.assertEqual('50abc.{pipe}.{extension}', c.get_name(first=50, second='abc'))
-        c.name = c.get_name(base='101dalmatians', version=1, extension='png')
+        self.assertEqual('{base}.{pipe}.{suffix}', c.get_name())
+        self.assertEqual('{base}.{pipe}.{suffix}', c.get_name(first=50))
+        self.assertEqual('50abc.{pipe}.{suffix}', c.get_name(first=50, second='abc'))
+        c.name = c.get_name(base='101dalmatians', version=1, suffix='png')
         self.assertEqual('101dalmatians', c.nice_name)
         self.assertEqual(
-            {'base': '101dalmatians', 'first': '101', 'second': 'dalmatians', 'version': '1', 'extension': 'png',
+            {'base': '101dalmatians', 'first': '101', 'second': 'dalmatians', 'version': '1', 'suffix': 'png',
              'pipe': '.1'},
             c.values)
         self.assertEqual('200dalmatians.1.png', c.get_name(first=200))
@@ -275,10 +275,10 @@ class TestPropertyField(unittest.TestCase):
                 return result
 
         pf = PropertyField(sep='_')
-        self.assertEqual(Path('{base}/{extrafield}/propertyfield/{base}_{extrafield}_staticvalue.{pipe}.{extension}'),
+        self.assertEqual(Path('{base}/{extrafield}/propertyfield/{base}_{extrafield}_staticvalue.{pipe}.{suffix}'),
                          pf.path)
         pf.name = 'simple_property_staticvalue.1.abc'
-        self.assertEqual({'base': 'simple', 'extrafield': 'property', 'version': '1', 'extension': 'abc', 'pipe': '.1',
+        self.assertEqual({'base': 'simple', 'extrafield': 'property', 'version': '1', 'suffix': 'abc', 'pipe': '.1',
                           'nameprop': 'staticvalue'},
                          pf.values)
         self.assertEqual('simple_property_staticvalue', pf.nice_name)
@@ -323,7 +323,7 @@ class TestSubclassing(unittest.TestCase):
         SubNamePF = type('SubNamePF', (self.SubName, PipeFile), {})
         n = SubNamePF()
         n.sep = ' - '
-        n.name = n.get_name(base='word', second_field='2nd', third_field='3rd', version=11, extension='png')
+        n.name = n.get_name(base='word', second_field='2nd', third_field='3rd', version=11, suffix='png')
         self.assertEqual('word - 2nd - 3rd.11.png', n.name)
         self.assertEqual('3rd', n.third_field)
         self.assertEqual('11', n.version)

--- a/naming/tests/__init__.py
+++ b/naming/tests/__init__.py
@@ -1,12 +1,7 @@
-# -*- coding: utf-8 -*-
-"""
-Names testing module.
-"""
-# standard
 import os
 import unittest
 from pathlib import Path
-# package
+
 from naming import *
 
 
@@ -14,8 +9,8 @@ class TestName(unittest.TestCase):
 
     def test_empty_name(self):
         n = Name()
-        self.assertEqual('[base]', n.get_name())
-        self.assertEqual('[base]', str(n))
+        self.assertEqual('{base}', n.get_name())
+        self.assertEqual('{base}', str(n))
 
     def test_init_name(self):
         n = Name('initname')
@@ -27,45 +22,43 @@ class TestName(unittest.TestCase):
 
     def test_set_name(self):
         n = Name()
-        n.set_name('setname')
+        n.name = 'setname'
         self.assertEqual('setname', n.get_name())
-        self.assertEqual(n, n.set_name('setname'))
-        self.assertTrue(isinstance(n.set_name('setname'), n.__class__))
+
+
+class TestConfig(unittest.TestCase):
+
+    def test_assignment(self):
+        n = Name()
+        with self.assertRaises(AttributeError):
+            n.config = 'foo'
+        cfg = n.config
+        cfg['base'] = 10
+        # check immutability
+        self.assertFalse(cfg == n.config)
 
 
 class TestEasyName(unittest.TestCase):
 
     def test_empty_name(self):
         n = Name()
-        self.assertEqual('[base]', n.get_name())
+        self.assertEqual('{base}', n.get_name())
         self.assertEqual({}, n.values)
 
     def test_new_empty_name(self):
         extra_fields = dict(year='[0-9]{4}', username='[a-z]+', anotherfield='(constant)', lastfield='[a-zA-Z0-9]+')
         Project = type('Project', (Name,), dict(config=extra_fields))
-        p = Project()
-        self.assertEqual('[base]_[year]_[username]_[anotherfield]_[lastfield]', p.get_name())
-        p.set_name('this_is_my_base_name_2017_christianl_constant_iamlast')
+        p = Project(sep='_')
+        self.assertEqual('{base}_{year}_{username}_{anotherfield}_{lastfield}', p.get_name())
+        p.name = 'this_is_my_base_name_2017_christianl_constant_iamlast'
         self.assertEqual('2017', p.year)
-
-    def test_set_name(self):
-        extra_fields = dict(year='[0-9]{4}', username='[a-z]+', anotherfield='(constant)', lastfield='[a-zA-Z0-9]+')
-        ProjectFile = type('ProjectFile', (PipeFile,), dict(config=extra_fields))
-        pf = ProjectFile('this_is_my_base_name_2017_christianl_constant_iamlast.base.17.abc')
-        self.assertEqual('this_is_my_base_name_2017_christianl_constant_iamlast', pf.nice_name)
-        self.assertEqual('this_is_my_base_name_2017_christianl_constant_iamlast.base.17', pf.pipe_name)
-        # setting same fields should be returning early
-        pf.year = 2017
-        self.assertEqual('2017', pf.year)
-        self.assertEqual('iamlast', pf.lastfield)
-        self.assertEqual('abc', pf.extension)
 
     def test_separator(self):
         extra_fields = dict(year='[0-9]{4}', username='[a-z]+', anotherfield='(constant)', lastfield='[a-zA-Z0-9]+')
         Project = type('Project', (Name,), dict(config=extra_fields))
-        p = Project('this_is_my_base_name_2017_christianl_constant_iamlast')
-        self.assertEqual('_', p.separator)
-        p.separator = '  '
+        p = Project('this_is_my_base_name_2017_christianl_constant_iamlast', sep='_')
+        self.assertEqual('_', p.sep)
+        p.sep = '  '
         self.assertEqual('this_is_my_base_name  2017  christianl  constant  iamlast', p.name)
 
 
@@ -73,27 +66,27 @@ class TestPipe(unittest.TestCase):
 
     def test_empty_name(self):
         p = Pipe()
-        self.assertEqual('[base].[pipe]', p.get_name())
-        self.assertEqual('[base].10', p.get_name(version=10))
-        self.assertEqual('[base].geo.10', p.get_name(version=10, output='geo'))
-        self.assertEqual('[base].geo.10.25', p.get_name(version=10, output='geo', frame=25))
-        self.assertEqual('[base].[output].10.25', p.get_name(version=10, frame=25))
-        self.assertEqual('[base].[output].[version].101', p.get_name(frame=101))
-        self.assertEqual('[base].cache.[version]', p.get_name(output='cache'))
-        self.assertEqual('[base]', p.get_name(pipe=None))
+        self.assertEqual('{base}.{pipe}', p.get_name())
+        self.assertEqual('{base}.10', p.get_name(version=10))
+        self.assertEqual('{base}.geo.10', p.get_name(version=10, output='geo'))
+        self.assertEqual('{base}.geo.10.25', p.get_name(version=10, output='geo', frame=25))
+        self.assertEqual('{base}.{output}.10.25', p.get_name(version=10, frame=25))
+        self.assertEqual('{base}.{output}.{version}.101', p.get_name(frame=101))
+        self.assertEqual('{base}.cache.{version}', p.get_name(output='cache'))
+        self.assertEqual('{base}', p.get_name(pipe=None))
 
     def test_empty_name_separator(self):
         p = Pipe()
         for sep in ' ', '.', '/', '/ .':
-            p.separator = sep
-            self.assertEqual(f'[base].[pipe]', p.get_name())
-            self.assertEqual('[base].10', p.get_name(version=10))
-            self.assertEqual(f'[base].geo.10', p.get_name(version=10, output='geo'))
-            self.assertEqual(f'[base].geo.10.25', p.get_name(version=10, output='geo', frame=25))
-            self.assertEqual(f'[base].[output].10.25', p.get_name(version=10, frame=25))
-            self.assertEqual(f'[base].[output].[version].101', p.get_name(frame=101))
-            self.assertEqual(f'[base].cache.[version]', p.get_name(output='cache'))
-            self.assertEqual('[base]', p.get_name(pipe=None))
+            p.sep = sep
+            self.assertEqual('{base}.{pipe}', p.get_name())
+            self.assertEqual('{base}.10', p.get_name(version=10))
+            self.assertEqual('{base}.geo.10', p.get_name(version=10, output='geo'))
+            self.assertEqual('{base}.geo.10.25', p.get_name(version=10, output='geo', frame=25))
+            self.assertEqual('{base}.{output}.10.25', p.get_name(version=10, frame=25))
+            self.assertEqual('{base}.{output}.{version}.101', p.get_name(frame=101))
+            self.assertEqual('{base}.cache.{version}', p.get_name(output='cache'))
+            self.assertEqual('{base}', p.get_name(pipe=None))
 
     def test_init_name(self):
         p = Pipe('initname.pipeline.0')
@@ -120,31 +113,31 @@ class TestPipe(unittest.TestCase):
 
     def test_set_name(self):
         p = Pipe()
-        p.set_name('setname.pipeline.0')
+        p.name = 'setname.pipeline.0'
         self.assertEqual('.pipeline.0', p.pipe)
         self.assertEqual('pipeline', p.output)
         self.assertEqual('0', p.version)
-        p.set_name('setname.pipeline.0.5')
+        p.name = 'setname.pipeline.0.5'
         self.assertEqual('5', p.frame)
         self.assertEqual('setname', p.nice_name)
 
     def test_values(self):
         p = Pipe()
-        p.set_name('my_pipe_file.1')
-        self.assertEqual({'base': 'my_pipe_file', 'version': '1'}, p.values)
+        p.name = 'my_pipe_file.1'
+        self.assertEqual({'base': 'my_pipe_file', 'version': '1', 'pipe': '.1'}, p.values)
 
     def test_get_empty_name(self):
         p = Pipe()
-        self.assertEqual('[base].[pipe]', p.pipe_name)
-        self.assertEqual('[base].[pipe]', p.get_name())
-        self.assertEqual('[base].out.7', p.get_name(pipe='.out.7'))
-        self.assertEqual('[base].out.[version]', p.get_name(output='out'))
-        self.assertEqual('[base].7', p.get_name(version=7))
-        self.assertEqual('[base].[output].[version].101', p.get_name(frame=101))
+        self.assertEqual('{base}.{pipe}', p.pipe_name)
+        self.assertEqual('{base}.{pipe}', p.get_name())
+        self.assertEqual('{base}.out.7', p.get_name(pipe='.out.7'))
+        self.assertEqual('{base}.out.{version}', p.get_name(output='out'))
+        self.assertEqual('{base}.7', p.get_name(version=7))
+        self.assertEqual('{base}.{output}.{version}.101', p.get_name(frame=101))
 
     def test_get_init_name(self):
         p = Pipe('my_pipe_file.7')
-        self.assertEqual('my_pipe_file.[output].7.101', p.get_name(frame=101))
+        self.assertEqual('my_pipe_file.{output}.7.101', p.get_name(frame=101))
         self.assertEqual('my_pipe_file.cache.7', p.get_name(output='cache'))
         self.assertEqual('my_pipe_file.8', p.get_name(version=int(p.version) + 1))
 
@@ -153,11 +146,11 @@ class TestFile(unittest.TestCase):
 
     def test_empty_name(self):
         f = File()
-        self.assertEqual('[base].[extension]', f.get_name())
-        self.assertEqual('[base].abc', f.get_name(extension='abc'))
-        self.assertEqual('[base].[extension]', f.get_name(extension=''))
+        self.assertEqual('{base}.{extension}', f.get_name())
+        self.assertEqual('{base}.abc', f.get_name(extension='abc'))
+        self.assertEqual('{base}.{extension}', f.get_name(extension=''))
 
-        f.set_name('myfile.ext')
+        f.name = 'myfile.ext'
         self.assertEqual('ext', f.extension)
         self.assertEqual('myfile', f.base)
         self.assertEqual(f.get_name(), str(f.path))
@@ -165,7 +158,6 @@ class TestFile(unittest.TestCase):
 
     def test_cwd(self):
         f = File()
-        f.full_path
         f.cwd = 'some/absolute/path'
         self.assertEqual(os.path.join('some', 'absolute', 'path', f.get_name()), str(f.full_path))
 
@@ -173,10 +165,10 @@ class TestPipeFile(unittest.TestCase):
 
     def test_empty_name(self):
         f = PipeFile()
-        self.assertEqual('[base].[pipe].[extension]', f.get_name())
-        self.assertEqual('[base].[pipe].abc', f.get_name(extension='abc'))
-        self.assertEqual('[base].[pipe].[extension]', f.get_name(extension=''))
-        f.set_name('myfile.data.0.ext')
+        self.assertEqual('{base}.{pipe}.{extension}', f.get_name())
+        self.assertEqual('{base}.{pipe}.abc', f.get_name(extension='abc'))
+        self.assertEqual('{base}.{pipe}.{extension}', f.get_name(extension=''))
+        f.name = 'myfile.data.0.ext'
         self.assertEqual('ext', f.extension)
         self.assertEqual('myfile', f.base)
         self.assertEqual('.data.0', f.pipe)
@@ -185,16 +177,16 @@ class TestPipeFile(unittest.TestCase):
 
     def test_set_property(self):
         pf = PipeFile()
-        self.assertEqual('[base].[pipe].[extension]', pf.get_name())
+        self.assertEqual('{base}.{pipe}.{extension}', pf.get_name())
         with self.assertRaises(NameError):
-            pf.base = 'awesome'
-        pf.set_name('hello_world.1.png')
+            pf.name = 'awesome'
+        pf.name = 'hello_world.1.png'
         pf.base = 'awesome'
         self.assertEqual('awesome', pf.nice_name)
-        self.assertEqual({'base': 'awesome', 'version': '1', 'extension': 'png'}, pf.values)
+        self.assertEqual({'base': 'awesome', 'version': '1', 'pipe': '.1', 'extension': 'png'}, pf.values)
 
         p = PipeFile('my_pipe_file.1.png')
-        self.assertEqual({'base': 'my_pipe_file', 'version': '1', 'extension': 'png'}, p.values)
+        self.assertEqual({'base': 'my_pipe_file', 'version': '1', 'extension': 'png', 'pipe': '.1'}, p.values)
         p.extension = 'abc'
         self.assertEqual('my_pipe_file.1.abc', p.name)
         p.output = 'geometry'
@@ -207,23 +199,35 @@ class TestPipeFile(unittest.TestCase):
         self.assertEqual('my_pipe_file.geometry.0.abc', p.name)
         self.assertEqual('PipeFile("my_pipe_file.geometry.0.abc")', repr(p))
 
+    def test_set_name(self):
+        extra_fields = dict(year='[0-9]{4}', username='[a-z]+', anotherfield='(constant)', lastfield='[a-zA-Z0-9]+')
+        ProjectFile = type('ProjectFile', (PipeFile,), dict(config=extra_fields))
+        pf = ProjectFile('this_is_my_base_name_2017_christianl_constant_iamlast.base.17.abc', sep='_')
+        self.assertEqual('this_is_my_base_name_2017_christianl_constant_iamlast', pf.nice_name)
+        self.assertEqual('this_is_my_base_name_2017_christianl_constant_iamlast.base.17', pf.pipe_name)
+        # setting same fields should be returning early
+        pf.year = 2017
+        self.assertEqual('2017', pf.year)
+        self.assertEqual('iamlast', pf.lastfield)
+        self.assertEqual('abc', pf.extension)
+
 
 class TestDrops(unittest.TestCase):
 
     def test_empty_name(self):
         Dropper = type('Dropper', (PipeFile,), dict(config=dict(without=r'[a-zA-Z0-9]+', basename=r'[a-zA-Z0-9]+'),
                                                     drops=('base',)))
-        d = Dropper()
-        self.assertEqual('[without]_[basename].[pipe].[extension]', d.get_name())
-        self.assertEqual('awesome_[basename].[pipe].[extension]', d.get_name(without='awesome'))
-        self.assertEqual('[without]_replaced.[output].[version].101.[extension]',
+        d = Dropper(sep='_')
+        self.assertEqual('{without}_{basename}.{pipe}.{extension}', d.get_name())
+        self.assertEqual('awesome_{basename}.{pipe}.{extension}', d.get_name(without='awesome'))
+        self.assertEqual('{without}_replaced.{output}.{version}.101.{extension}',
                          d.get_name(basename='replaced', frame=101))
 
         Subdropper = type('Dropper', (Dropper,), dict(config=dict(subdrop='[\w]')))
-        s = Subdropper()
-        self.assertEqual('[without]_[basename]_[subdrop].[pipe].[extension]', s.get_name())
-        self.assertEqual('awesome_[basename]_[subdrop].[pipe].[extension]', s.get_name(without='awesome'))
-        self.assertEqual('[without]_replaced_[subdrop].[output].[version].101.[extension]',
+        s = Subdropper(sep='_')
+        self.assertEqual('{without}_{basename}_{subdrop}.{pipe}.{extension}', s.get_name())
+        self.assertEqual('awesome_{basename}_{subdrop}.{pipe}.{extension}', s.get_name(without='awesome'))
+        self.assertEqual('{without}_replaced_{subdrop}.{output}.{version}.101.{extension}',
                          s.get_name(basename='replaced', frame=101))
 
 
@@ -232,14 +236,15 @@ class TestCompound(unittest.TestCase):
     def test_empty_name(self):
         Compound = type('Compound', (PipeFile,), dict(config=dict(first=r'[\d]+', second=r'[a-zA-Z]+'),
                                                       compounds=dict(base=('first', 'second'))))
-        c = Compound()
-        self.assertEqual('[base].[pipe].[extension]', c.get_name())
-        self.assertEqual('[base].[pipe].[extension]', c.get_name(first=50))
-        self.assertEqual('50abc.[pipe].[extension]', c.get_name(first=50, second='abc'))
-        c.set_name(c.get_name(base='101dalmatians', version=1, extension='png'))
+        c = Compound(sep='_')
+        self.assertEqual('{base}.{pipe}.{extension}', c.get_name())
+        self.assertEqual('{base}.{pipe}.{extension}', c.get_name(first=50))
+        self.assertEqual('50abc.{pipe}.{extension}', c.get_name(first=50, second='abc'))
+        c.name = c.get_name(base='101dalmatians', version=1, extension='png')
         self.assertEqual('101dalmatians', c.nice_name)
         self.assertEqual(
-            {'base': '101dalmatians', 'first': '101', 'second': 'dalmatians', 'version': '1', 'extension': 'png'},
+            {'base': '101dalmatians', 'first': '101', 'second': 'dalmatians', 'version': '1', 'extension': 'png',
+             'pipe': '.1'},
             c.values)
         self.assertEqual('200dalmatians.1.png', c.get_name(first=200))
 
@@ -268,10 +273,126 @@ class TestPropertyField(unittest.TestCase):
                 result.append('nameprop')
                 return result
 
-        pf = PropertyField()
-        self.assertEqual(Path('[base]/[extrafield]/[pathprop]/[base]_[extrafield]_[nameprop].[pipe].[extension]'), pf.path)
-        pf.set_name('simple_property_staticvalue.1.abc')
-        self.assertEqual({'base': 'simple', 'extrafield': 'property', 'version': '1', 'extension': 'abc'},
+        pf = PropertyField(sep='_')
+        self.assertEqual(Path('{base}/{extrafield}/propertyfield/{base}_{extrafield}_staticvalue.{pipe}.{extension}'),
+                         pf.path)
+        pf.name = 'simple_property_staticvalue.1.abc'
+        self.assertEqual({'base': 'simple', 'extrafield': 'property', 'version': '1', 'extension': 'abc', 'pipe': '.1',
+                          'nameprop': 'staticvalue'},
                          pf.values)
         self.assertEqual('simple_property_staticvalue', pf.nice_name)
         self.assertEqual(Path('simple/property/propertyfield/simple_property_staticvalue.1.abc'), pf.path)
+
+
+class TestSubclassing(unittest.TestCase):
+    SubName = type('SubName', (Name,), dict(config=dict(base=r'\w+', second_field='(2nd)', third_field='(3rd)')))
+    SubName2 = type('SubName2', (SubName,), dict(config=dict(second_field='(notsec)')))
+    Replace = type('Replace', (SubName2,), dict(config=dict(base='(repl)', fourth_field='(4th)', fifth_field='(5th)')))
+    SubName3 = type('SubName3', (SubName2,), dict(config=dict(base='(mrb)', second_field='(dos)')))
+    Drop = type('Drop', (Replace,), dict(drops=('fourth_field',)))
+
+    class Compounds(Drop):
+        config = dict(subfirst='(s1st)', subscnd='(s2nd)', f1='(f1)', f2='(f2)', lastfield='(last)')
+        compounds = dict(second_field=('subfirst', 'subscnd'), fifth_field=('f1', 'f2'))
+
+    class Subcoms(Compounds):
+        compounds = dict(base=('second_field', 'third_field'), fifth_field=('fifth_field', 'lastfield'))
+
+    class Subcoms2(Compounds):
+        config = dict(another='(another)', nested='(nested)')
+        compounds = dict(base=('second_field', 'third_field'), fifth_field=('f1', 'f2', 'lastfield'))
+
+    class Subcoms3(Subcoms2):
+        config = dict(nombre='(nombre)', apellido='(apellido)', middlename='(medio)')
+
+    class SS5(Subcoms3):
+        config = dict(morename='(masnombres)')
+        compounds = dict(nombre=('nombre', 'middlename', 'another'), apellido=('morename', 'apellido'))
+
+    def test_config_only(self):
+        n = self.SubName()
+        self.assertEqual('{base} {second_field} {third_field}', n.get_name())
+        n.name = 'word 2nd 3rd'
+        self.assertEqual('2nd', n.second_field)
+        with self.assertRaises(NameError):
+            n.second_field = 'notsec'
+        n = self.SubName2(n.get_name(second_field='notsec'))
+        self.assertEqual('word notsec 3rd', n.name)
+        values = n.values
+        n = self.Replace()
+        with self.assertRaises(NameError):
+            n.base = 'repl'
+        values.update(base='repl', fourth_field='4th', fifth_field='5th')
+        n.name = n.get_name(**values)
+        self.assertEqual('repl notsec 3rd 4th 5th', n.name)
+        with self.assertRaises(NameError):
+            self.SubName3('mrb dos 3r')
+        n = self.SubName3('mrb dos 3rd')
+        self.assertEqual('mrb', n.base)
+
+    def test_drops(self):
+        n = self.Drop()
+        self.assertEqual('{base} {second_field} {third_field} {fifth_field}', n.get_name())
+        n.name = 'repl notsec 3rd 5th'
+        self.assertEqual('notsec', n.second_field)
+        with self.assertRaises(NameError):
+            n.third_field = 'tres'
+        n = self.Compounds()
+        self.assertEqual('{base} {second_field} {third_field} {fifth_field} {lastfield}', n.get_name())
+        n.name = 'repl s1sts2nd 3rd f1f2 last'
+        self.assertEqual('s1st', n.subfirst)
+        values = n.values
+        n = self.Subcoms()
+        self.assertEqual('{base} {fifth_field} {f1} {f2}', n.get_name())
+        values.update(base=rf'{values["second_field"]}{values["third_field"]}',
+                      fifth_field=rf'5th{values["lastfield"]}')
+        n.name = n.get_name(**values)
+        self.assertEqual('s1sts2nd3rd 5thlast f1 f2', n.name)
+        self.assertEqual('s1sts2nd3rd', n.base)
+        self.assertEqual('3rd', n.third_field)
+        self.assertEqual('5thlast', n.fifth_field)
+        self.assertEqual('last', n.lastfield)
+        with self.assertRaises(NameError):
+            n.base = 'repls'
+        n = self.Subcoms2()
+        self.assertEqual('{base} {fifth_field} {another} {nested}', n.get_name())
+        self.assertEqual('s1sts2nd3rd {fifth_field} {another} {nested}', n.get_name(f1='f1', f2='f2',
+                                                                                    second_field=values['second_field'],
+                                                                                    third_field=values['third_field']))
+        n = self.SS5()
+        self.assertEqual('{base} {fifth_field} {nested} {nombre} {apellido}', n.get_name())
+        values['fifth_field'] = None
+        # compounds that were redeclared with a nested name should have precedence
+        values.update(nombre='nombremedioanother', apellido='masnombresapellido', middlename='medio',
+                      morename='masnombres', another='another', nested='nested', f1='f1', f2='f2')
+        n.name = n.get_name(**values)
+        self.assertEqual('s1sts2nd3rd f1f2last nested nombremedioanother masnombresapellido', n.name)
+        with self.assertRaises(NameError):
+            self.SubName3('mrb dos 3r')
+        self.assertEqual('masnombres', n.morename)
+
+
+    def test_compounds(self):
+        class ComplicatedCompound(Name):
+            config = dict(one='1st', two='2nd', three='3rd', four='4th', five='5th', six='6th', seven='7th',
+                          eight='8th', nine='9th', zero='0')
+            compounds = dict(two=('two', 'one', 'base'),
+                             one=('seven', 'six', 'five'),
+                             six=('three', 'four'),
+                             base=('nine', 'eight')
+                             )
+
+        n = ComplicatedCompound('2nd7th3rd4th5th9th8th 0')
+        self.assertEqual('7th3rd4th5th', n.one)
+        self.assertEqual('2nd7th3rd4th5th9th8th', n.two)
+        self.assertEqual('3rd', n.three)
+        self.assertEqual('4th', n.four)
+        self.assertEqual('5th', n.five)
+        self.assertEqual('3rd4th', n.six)
+        self.assertEqual('7th', n.seven)
+        self.assertEqual('8th', n.eight)
+        self.assertEqual('9th', n.nine)
+        self.assertEqual('0', n.zero)
+        self.assertEqual('9th8th', n.base)
+        with self.assertRaises(NameError):
+            n.six = 'madman'

--- a/naming/tests/__init__.py
+++ b/naming/tests/__init__.py
@@ -154,12 +154,12 @@ class TestFile(unittest.TestCase):
         self.assertEqual('ext', f.suffix)
         self.assertEqual('myfile', f.base)
         self.assertEqual(f.get_name(), str(f.path))
-        self.assertEqual(os.path.join(Path.home(), f.get_name()), str(f.full_path))
+        self.assertEqual(os.path.join(Path.home(), f.get_name()), str(f.fullpath))
 
     def test_cwd(self):
         f = File()
         f.cwd = 'some/absolute/path'
-        self.assertEqual(os.path.join('some', 'absolute', 'path', f.get_name()), str(f.full_path))
+        self.assertEqual(os.path.join('some', 'absolute', 'path', f.get_name()), str(f.fullpath))
 
 
 class TestPipeFile(unittest.TestCase):
@@ -309,6 +309,23 @@ class TestSubclassing(unittest.TestCase):
     class SS5(Subcoms3):
         config = dict(morename='(masnombres)')
         compounds = dict(nombre=('nombre', 'middlename', 'another'), apellido=('morename', 'apellido'))
+
+    def test_sep(self):
+        n = self.SubName()
+        self.assertEqual('{base} {second_field} {third_field}', n.get_name())
+        n.sep = 'p'
+        self.assertEqual('p', n.sep)
+        self.assertEqual('hellop{second_field}p{third_field}', n.get_name(base='hello'))
+        self.assertEqual({}, n.values)
+        with self.assertRaises(NameError):
+            n.name = n.get_name(base='hello', second_field='2nd', third_field='3r')
+        n.name = n.get_name(base='hello', second_field='2nd', third_field='3rd')
+        self.assertEqual({'base': 'hello', 'second_field': '2nd', 'third_field': '3rd'}, n.values)
+        n.sep = '?'
+        self.assertEqual('hello?2nd?3rd', n.name)
+        self.assertEqual('sups?2nd?3rd', n.get_name(base='sups'))
+        n.sep = '?*&'
+        self.assertEqual('hello?*&2nd?*&3rd', n.name)
 
     def test_config_only(self):
         n = self.SubName()

--- a/naming/tests/__init__.py
+++ b/naming/tests/__init__.py
@@ -33,9 +33,9 @@ class TestConfig(unittest.TestCase):
         with self.assertRaises(AttributeError):
             n.config = 'foo'
         cfg = n.config
-        cfg['base'] = 10
-        # check immutability
-        self.assertFalse(cfg == n.config)
+        with self.assertRaises(TypeError):
+            cfg['base'] = 10
+        self.assertTrue(cfg == n.config)
 
 
 class TestEasyName(unittest.TestCase):
@@ -160,6 +160,7 @@ class TestFile(unittest.TestCase):
         f = File()
         f.cwd = 'some/absolute/path'
         self.assertEqual(os.path.join('some', 'absolute', 'path', f.get_name()), str(f.full_path))
+
 
 class TestPipeFile(unittest.TestCase):
 
@@ -319,6 +320,13 @@ class TestSubclassing(unittest.TestCase):
         n = self.SubName2(n.get_name(second_field='notsec'))
         self.assertEqual('word notsec 3rd', n.name)
         values = n.values
+        SubNamePF = type('SubNamePF', (self.SubName, PipeFile), {})
+        n = SubNamePF()
+        n.sep = ' - '
+        n.name = n.get_name(base='word', second_field='2nd', third_field='3rd', version=11, extension='png')
+        self.assertEqual('word - 2nd - 3rd.11.png', n.name)
+        self.assertEqual('3rd', n.third_field)
+        self.assertEqual('11', n.version)
         n = self.Replace()
         with self.assertRaises(NameError):
             n.base = 'repl'

--- a/naming/tests/__init__.py
+++ b/naming/tests/__init__.py
@@ -258,6 +258,18 @@ class TestCompound(unittest.TestCase):
             def get_pattern_list(self):
                 return ['cmp'] + super().get_pattern_list()
 
+        class CompAndPropsInvalid(CompUnused):
+            # by compounding 'base', get_pattern_list will return an empty list, should fail to initialise
+            compounds = dict(cmp2=('base', 'prop'))
+
+            @property
+            def prop(self):
+                return 'constant'
+
+        class CompAndPropsValid(CompAndPropsInvalid):
+            def get_pattern_list(self):
+                return ['cmp', 'cmp2']
+
         c = CompUnused()
         self.assertEqual('{base}', c.get_name())
         c.name = 'hello_world'
@@ -270,6 +282,21 @@ class TestCompound(unittest.TestCase):
         c.name = '12 hello_world'
         self.assertEqual('12', c.cmp)
         self.assertEqual({'base': 'hello_world', 'cmp': '12', 'first': '1', 'second': '2'}, c.values)
+
+        with self.assertRaises(ValueError):
+            CompAndPropsInvalid()
+
+        c = CompAndPropsValid()
+        self.assertEqual('{cmp} {cmp2}', c.get_name())
+        c.name = '12 hello_worldccconstant'
+        self.assertEqual('12', c.cmp)
+        self.assertEqual('hello_worldccconstant', c.cmp2)
+        self.assertEqual({'base': 'hello_worldcc',
+                          'cmp': '12',
+                          'cmp2': 'hello_worldccconstant',
+                          'first': '1',
+                          'prop': 'constant',
+                          'second': '2'}, c.values)
 
 
 class TestPropertyField(unittest.TestCase):


### PR DESCRIPTION
### Added
- `NameConfig` object that allows subclasses to use more configurations apart from the builtin `config`.

### Changed
- Missing fields now have f-strings syntax: `{missing}` instead of `[missing]`.
- Setting fields or name to an incorrect value raises a `ValueError` instead of a `NameError`.
- `name` property is no longer read-only.
- `separator` property is now called `sep`.
- `Pipe.pipe_separator` is now called `Pipe.pipe_sep`
- `File` object now uses `suffix` instead of `extension` as a special field.

### Removed
- `set_name` method (use `name` property instead).
- `File.full_path` & `File.cwd`. These attributes didn't add more than what the [pathlib](https://docs.python.org/3/library/pathlib.html) module already offers.

### Fixed
- `compounds` attribute allows for more use cases (redefined fields, new field names not present on the `config` attribute)
