### PR TITLE
Python-3.14 on CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install .
       - name: Test
         run: |
-          pytest --cov --durations=10 .
+          PYTHONWARNINGS=error pytest --cov --durations=10 .
         # https://github.com/marketplace/actions/codecov
       - name: Codecov Report
         uses: codecov/codecov-action@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.13", "3.13t"]
+        python-version: ["3.9", "3.14", "3.14t"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install .
       - name: Test
         run: |
-          pytest --cov .
+          pytest --cov --durations=10 .
         # https://github.com/marketplace/actions/codecov
       - name: Codecov Report
         uses: codecov/codecov-action@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,12 +10,12 @@ author = Christian López Barrón
 url = https://github.com/chrizzFTD/naming
 # Try to align to https://devguide.python.org/versions/
 classifiers =
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 
 [options]
 packages = find:

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -273,7 +273,7 @@ class TestDrops(unittest.TestCase):
         self.assertEqual('{without}_replaced.{output}.{version}.101.{suffix}',
                          d.get(basename='replaced', index=101))
 
-        Subdropper = type('Dropper', (Dropper,), dict(config=dict(subdrop='[\w]')))
+        Subdropper = type('Dropper', (Dropper,), dict(config=dict(subdrop=r'[\w]')))
         s = Subdropper(sep='_')
         self.assertEqual('{without}_{basename}_{subdrop}.{pipe}.{suffix}', s.get())
         self.assertEqual('awesome_{basename}_{subdrop}.{pipe}.{suffix}', s.get(without='awesome'))


### PR DESCRIPTION
- CI python range is now 3.9 -> 3.14 & 3.14t
- Added slow tests durations report
- Enabled warnings as errors