### PR TITLE
Add interactive REPL to Overview docs

### DIFF
--- a/docs/source/Overview.rst
+++ b/docs/source/Overview.rst
@@ -20,237 +20,220 @@ Usage
     Inherit from the class to use and assign a class attribute `config` as a
     mapping of {field_name: regex_pattern} to use.
 
-    Name::
+    Name
 
-        >>> from naming import Name
-        >>> class BasicName(Name):
-        ...     config = dict(base=r'\w+')
-        ...
-        >>> n = BasicName()
-        >>> n.get()  # no name has been set on the object, convention is solved with {missing} fields
-        '{base}'
-        >>> n.values
-        {}
-        >>> n.name = 'hello_world'
-        >>> n
-        Name("hello_world")
-        >>> str(n)  # cast to string
-        'hello_world'
-        >>> n.values
-        {'base': 'hello_world'}
-        >>> # modify name and get values from field names
-        >>> n.base = 'through_field_name'
-        >>> n.values
-        {'base': 'through_field_name'}
-        >>> n.base
-        'through_field_name'
+    .. py-repl::
+       :packages: naming
+       :repl-title: Name
+       :no-banner:
 
-    Pipe::
+       >>> from naming import Name
+       >>> class BasicName(Name):
+       ...     config = dict(base=r'\w+')
+       ...
+       >>> n = BasicName()
+       >>> n.get()  # no name has been set on the object, convention is solved with {missing} fields
+       >>> n.values
+       >>> n.name = 'hello_world'
+       >>> n
+       >>> str(n)  # cast to string
+       >>> n.values
+       >>> # modify name and get values from field names
+       >>> n.base = 'through_field_name'
+       >>> n.values
+       >>> n.base
 
-        >>> from naming import Pipe
-        >>> class BasicPipe(Pipe):
-        ...     config = dict(base=r'\w+')
-        ...
-        >>> p = BasicPipe()
-        >>> p.get()
-        '{base}.{pipe}'
-        >>> p.get(version=10)
-        '{base}.10'
-        >>> p.get(output='data')
-        '{base}.data.{version}'
-        >>> p.get(output='cache', version=7, index=24)
-        '{base}.cache.7.24'
-        >>> p = BasicPipe('my_wip_data.1')
-        >>> p.version
-        '1'
-        >>> p.values
-        {'base': 'my_wip_data', 'pipe': '.1', 'version': '1'}
-        >>> p.get(output='exchange')  # returns a new string
-        'my_wip_data.exchange.1'
-        >>> p.name
-        'my_wip_data.1'
-        >>> p.output = 'exchange'  # mutates the object
-        >>> p.name
-        'my_wip_data.exchange.1'
-        >>> p.index = 101
-        >>> p.version = 7
-        >>> p.name
-        'my_wip_data.exchange.7.101'
-        >>> p.values
-        {'base': 'my_wip_data', 'pipe': '.exchange.7.101', 'output': 'exchange', 'version': '7', 'index': '101'}
+    Pipe
 
-    File::
+    .. py-repl::
+       :packages: naming
+       :repl-title: Pipe
+       :no-banner:
 
-        >>> from naming import File
-        >>> class BasicFile(File):
-        ...     config = dict(base=r'\w+')
-        ...
-        >>> f = BasicFile()
-        >>> f.get()
-        '{basse}.{suffix}'
-        >>> f.get(suffix='png')
-        '{base}.png'
-        >>> f = BasicFile('hello.world')
-        >>> f.values
-        {'base': 'hello', 'suffix': 'world'}
-        >>> f.suffix
-        'world'
-        >>> f.suffix = 'abc'
-        >>> f.name
-        'hello.abc'
-        >>> f.path
-        WindowsPath('hello.abc')
+       >>> from naming import Pipe
+       >>> class BasicPipe(Pipe):
+       ...     config = dict(base=r'\w+')
+       ...
+       >>> p = BasicPipe()
+       >>> p.get()
+       >>> p.get(version=10)
+       >>> p.get(output='data')
+       >>> p.get(output='cache', version=7, index=24)
+       >>> p = BasicPipe('my_wip_data.1')
+       >>> p.version
+       >>> p.values
+       >>> p.get(output='exchange')  # returns a new string
+       >>> p.name
+       >>> p.output = 'exchange'  # mutates the object
+       >>> p.name
+       >>> p.index = 101
+       >>> p.version = 7
+       >>> p.name
+       >>> p.values
 
-    PipeFile::
+    File
 
-        >>> from naming import PipeFile
-        >>> class BasicPipeFile(PipeFile):
-        ...     config = dict(base=r'\w+')
-        ...
-        >>> p = BasicPipeFile('wipfile.7.ext')
-        >>> p.values
-        {'base': 'wipfile', 'pipe': '.7', 'version': '7', 'suffix': 'ext'}
-        >>> [p.get(index=x, output='render') for x in range(10)]
-        ['wipfile.render.7.0.ext',
-        'wipfile.render.7.1.ext',
-        'wipfile.render.7.2.ext',
-        'wipfile.render.7.3.ext',
-        'wipfile.render.7.4.ext',
-        'wipfile.render.7.5.ext',
-        'wipfile.render.7.6.ext',
-        'wipfile.render.7.7.ext',
-        'wipfile.render.7.8.ext',
-        'wipfile.render.7.9.ext']
+    .. py-repl::
+       :packages: naming
+       :repl-title: File
+       :no-banner:
+
+       >>> from naming import File
+       >>> class BasicFile(File):
+       ...     config = dict(base=r'\w+')
+       ...
+       >>> f = BasicFile()
+       >>> f.get()
+       >>> f.get(suffix='png')
+       >>> f = BasicFile('hello.world')
+       >>> f.values
+       >>> f.suffix
+       >>> f.suffix = 'abc'
+       >>> f.name
+       >>> f.path
+
+    PipeFile
+
+    .. py-repl::
+       :packages: naming
+       :repl-title: PipeFile
+       :no-banner:
+
+       >>> from naming import PipeFile
+       >>> class BasicPipeFile(PipeFile):
+       ...     config = dict(base=r'\w+')
+       ...
+       >>> p = BasicPipeFile('wipfile.7.ext')
+       >>> p.values
+       >>> [p.get(index=x, output='render') for x in range(10)]
 
 .. topic:: Extending Names
 
     The **config**, **drop** and **join** attributes are merged on subclasses.
 
-    Inheriting from an existing name::
+    Inheriting from an existing name
 
-        >>> class ProjectFile(BasicPipeFile):
-        ...     config = dict(year='[0-9]{4}',
-        ...                   user='[a-z]+',
-        ...                   another='(constant)',
-        ...                   last='[a-zA-Z0-9]+')
-        ...
-        >>> pf = ProjectFile('project_data_name_2017_christianl_constant_iamlast.data.17.abc', sep='_')
-        >>> pf.values
-        {'base': 'project_data_name',
-        'year': '2017',
-        'user': 'christianl',
-        'another': 'constant',
-        'last': 'iamlast',
-        'pipe': '.data.17',
-        'output': 'data',
-        'version': '17',
-        'suffix': 'abc'}
-        >>> pf.nice_name  # no pipe & suffix fields
-        'project_data_name_2017_christianl_constant_iamlast'
-        >>> pf.year
-        '2017'
-        >>> pf.year = 'nondigits'  # mutating with invalid fields raises a ValueError
-        Traceback (most recent call last):
-        ...
-        ValueError: Can't set field 'year' with invalid value 'nondigits' on 'ProjectFile("project_data_name_2017_christianl_constant_iamlast.data.17.abc")'. A valid field value should match pattern: '[0-9]{4}'
-        >>> pf.year = 1907
-        >>> pf
-        ProjectFile("project_data_name_1907_christianl_constant_iamlast.data.17.abc")
-        >>> pf.suffix
-        'abc'
-        >>> pf.sep = '  '  # you can set the separator to a different set of characters
-        >>> pf.name
-        'project_data_name   1907   christianl   constant   iamlast.data.17.abc'
+    .. py-repl::
+       :packages: naming
+       :src: _static/pyrepl_bootstrap.py
+       :repl-title: Extending names
+       :no-banner:
 
-    Dropping fields from bases::
+       >>> class ProjectFile(BasicPipeFile):
+       ...     config = dict(year='[0-9]{4}',
+       ...                   user='[a-z]+',
+       ...                   another='(constant)',
+       ...                   last='[a-zA-Z0-9]+')
+       ...
+       >>> pf = ProjectFile('project_data_name_2017_christianl_constant_iamlast.data.17.abc', sep='_')
+       >>> pf.values
+       >>> pf.nice_name  # no pipe & suffix fields
+       >>> pf.year
+       >>> pf.year = 'nondigits'  # mutating with invalid fields raises a ValueError
+       >>> pf.year = 1907
+       >>> pf
+       >>> pf.suffix
+       >>> pf.sep = '  '  # you can set the separator to a different set of characters
+       >>> pf.name
 
-        >>> class Dropper(BasicPipeFile):
-        ...     config = dict(without=r'[a-zA-Z0-9]+', basename=r'[a-zA-Z0-9]+')
-        ...     drop=('base',)
-        ...
-        >>> d = Dropper()
-        >>> d.get()
-        '{without}_{basename}.{pipe}.{suffix}'
-        >>> # New subclasses will drop the 'base' field as well
-        >>> Subdropper = type('Dropper', (Dropper,), dict(config=dict(subdrop='[\w]')))
-        >>> s = Subdropper()
-        >>> s.get()
-        '{without}_{basename}_{subdrop}.{pipe}.{suffix}'
+    Dropping fields from bases
 
-    Setting compound fields::
+    .. py-repl::
+       :packages: naming
+       :src: _static/pyrepl_bootstrap.py
+       :repl-title: Dropping fields
+       :no-banner:
 
-        >>> # splitting the 'base' field into multiple joined fields
-        >>> class Compound(BasicPipeFile):
-        ...     config=dict(first=r'\d+', second=r'[a-zA-Z]+')
-        ...     join=dict(base=('first', 'second'))
-        ...
-        >>> c = Compound()
-        >>> c.get()  # we see the original field 'base'
-        '{base}.{pipe}.{suffix}'
-        >>> c.get(first=50, second='abc')  # providing each field to join will work
-        '50abc.{pipe}.{suffix}'
-        >>> c.name = c.get(base='101dalmatians', version=1, suffix='png')  # providing the key field will also work
-        >>> c.nice_name
-        '101dalmatians'
-        >>> c.get(first=200)
-        '200dalmatians.1.png'
-        >>> class CompoundByDash(Compound):
-        ...     join_sep = '-'  # you can specify the string to join compounds
-        ...
-        >>> c = CompoundByDash('101-dalmatians.1.png')
-        >>> c.get(first=300)
-        '300-dalmatians.1.png'
+       >>> class Dropper(BasicPipeFile):
+       ...     config = dict(without=r'[a-zA-Z0-9]+', basename=r'[a-zA-Z0-9]+')
+       ...     drop=('base',)
+       ...
+       >>> d = Dropper()
+       >>> d.get()
+       >>> # New subclasses will drop the 'base' field as well
+       >>> Subdropper = type('Dropper', (Dropper,), dict(config=dict(subdrop='[\w]')))
+       >>> s = Subdropper()
+       >>> s.get()
 
-    Defining path rules for File subclasses::
+    Setting compound fields
 
-        >>> from naming import File
-        >>> class FilePath(File):
-        ...     config = dict(base=r'\w+', extrafield='[a-z0-9]+')
-        ...     def get_path_pattern_list(self):
-        ...         # As an example we are returning the pattern list from the name object (base, extrafield)
-        ...         return super().get_pattern_list()
-        ...
-        >>> fp = FilePath()
-        >>> fp.get()
-        '{base} {extrafield}.{suffix}'
-        >>> # path attribute will vary depending on the OS
-        >>> fp.path
-        WindowsPath('{base}/{extrafield}/{base} {extrafield}.{suffix}')
+    .. py-repl::
+       :packages: naming
+       :src: _static/pyrepl_bootstrap.py
+       :repl-title: Compound fields
+       :no-banner:
 
-    Using properties as fields while solving names::
+       >>> # splitting the 'base' field into multiple joined fields
+       >>> class Compound(BasicPipeFile):
+       ...     config=dict(first=r'\d+', second=r'[a-zA-Z]+')
+       ...     join=dict(base=('first', 'second'))
+       ...
+       >>> c = Compound()
+       >>> c.get()  # we see the original field 'base'
+       >>> c.get(first=50, second='abc')  # providing each field to join will work
+       >>> c.name = c.get(base='101dalmatians', version=1, suffix='png')  # providing the key field will also work
+       >>> c.nice_name
+       >>> c.get(first=200)
+       >>> class CompoundByDash(Compound):
+       ...     join_sep = '-'  # you can specify the string to join compounds
+       ...
+       >>> c = CompoundByDash('101-dalmatians.1.png')
+       >>> c.get(first=300)
 
-        >>> from naming import PipeFile
-        >>> class PropertyField(PipeFile):
-        ...     config = dict(base=r'\w+', extrafield='[a-z0-9]+')
-        ...
-        ...     @property
-        ...     def nameproperty(self):
-        ...         return 'staticvalue'
-        ...
-        ...     @property
-        ...     def pathproperty(self):
-        ...         return 'path_field'
-        ...
-        ...     def get_path_pattern_list(self):
-        ...         result = super().get_pattern_list()
-        ...         result.append('pathproperty')
-        ...         return result
-        ...
-        ...     def get_pattern_list(self):
-        ...         result = super().get_pattern_list()
-        ...         result.append('nameproperty')
-        ...         return result
-        ...
-        >>> pf = PropertyField()
-        >>> pf.get()
-        '{base} {extrafield} staticvalue.{pipe}.{suffix}'
-        >>> pf.name = 'simple props staticvalue.1.abc'
-        >>> pf.values
-        {'base': 'simple',
-        'extrafield': 'props',
-        'nameproperty': 'staticvalue',
-        'pipe': '.1',
-        'version': '1',
-        'suffix': 'abc'}
-        >>> pf.path
-        WindowsPath('simple/props/path_field/simple props staticvalue.1.abc')
+    Defining path rules for File subclasses
+
+    In the browser REPL, paths appear as ``PosixPath``.
+
+    .. py-repl::
+       :packages: naming
+       :repl-title: Path rules
+       :no-banner:
+
+       >>> from naming import File
+       >>> class FilePath(File):
+       ...     config = dict(base=r'\w+', extrafield='[a-z0-9]+')
+       ...     def get_path_pattern_list(self):
+       ...         # As an example we are returning the pattern list from the name object (base, extrafield)
+       ...         return super().get_pattern_list()
+       ...
+       >>> fp = FilePath()
+       >>> fp.get()
+       >>> # path attribute will vary depending on the OS
+       >>> fp.path
+
+    Using properties as fields while solving names
+
+    In the browser REPL, paths appear as ``PosixPath``.
+
+    .. py-repl::
+       :packages: naming
+       :repl-title: Property fields
+       :no-banner:
+
+       >>> from naming import PipeFile
+       >>> class PropertyField(PipeFile):
+       ...     config = dict(base=r'\w+', extrafield='[a-z0-9]+')
+       ...
+       ...     @property
+       ...     def nameproperty(self):
+       ...         return 'staticvalue'
+       ...
+       ...     @property
+       ...     def pathproperty(self):
+       ...         return 'path_field'
+       ...
+       ...     def get_path_pattern_list(self):
+       ...         result = super().get_pattern_list()
+       ...         result.append('pathproperty')
+       ...         return result
+       ...
+       ...     def get_pattern_list(self):
+       ...         result = super().get_pattern_list()
+       ...         result.append('nameproperty')
+       ...         return result
+       ...
+       >>> pf = PropertyField()
+       >>> pf.get()
+       >>> pf.name = 'simple props staticvalue.1.abc'
+       >>> pf.values
+       >>> pf.path

--- a/docs/source/Overview.rst
+++ b/docs/source/Overview.rst
@@ -213,25 +213,20 @@ Usage
        >>> from naming import PipeFile
        >>> class PropertyField(PipeFile):
        ...     config = dict(base=r'\w+', extrafield='[a-z0-9]+')
-       ...
        ...     @property
        ...     def nameproperty(self):
        ...         return 'staticvalue'
-       ...
        ...     @property
        ...     def pathproperty(self):
        ...         return 'path_field'
-       ...
        ...     def get_path_pattern_list(self):
        ...         result = super().get_pattern_list()
        ...         result.append('pathproperty')
        ...         return result
-       ...
        ...     def get_pattern_list(self):
        ...         result = super().get_pattern_list()
        ...         result.append('nameproperty')
        ...         return result
-       ...
        >>> pf = PropertyField()
        >>> pf.get()
        >>> pf.name = 'simple props staticvalue.1.abc'

--- a/docs/source/Overview.rst
+++ b/docs/source/Overview.rst
@@ -30,6 +30,7 @@ Usage
        >>> from naming import Name
        >>> class BasicName(Name):
        ...     config = dict(base=r'\w+')
+       ...
        >>> n = BasicName()
        >>> n.get()  # no name has been set on the object, convention is solved with {missing} fields
        >>> n.values
@@ -52,6 +53,7 @@ Usage
        >>> from naming import Pipe
        >>> class BasicPipe(Pipe):
        ...     config = dict(base=r'\w+')
+       ...
        >>> p = BasicPipe()
        >>> p.get()
        >>> p.get(version=10)
@@ -79,6 +81,7 @@ Usage
        >>> from naming import File
        >>> class BasicFile(File):
        ...     config = dict(base=r'\w+')
+       ...
        >>> f = BasicFile()
        >>> f.get()
        >>> f.get(suffix='png')
@@ -99,6 +102,7 @@ Usage
        >>> from naming import PipeFile
        >>> class BasicPipeFile(PipeFile):
        ...     config = dict(base=r'\w+')
+       ...
        >>> p = BasicPipeFile('wipfile.7.ext')
        >>> p.values
        >>> [p.get(index=x, output='render') for x in range(10)]
@@ -120,6 +124,7 @@ Usage
        ...                   user='[a-z]+',
        ...                   another='(constant)',
        ...                   last='[a-zA-Z0-9]+')
+       ...
        >>> pf = ProjectFile('project_data_name_2017_christianl_constant_iamlast.data.17.abc', sep='_')
        >>> pf.values
        >>> pf.nice_name  # no pipe & suffix fields
@@ -142,6 +147,7 @@ Usage
        >>> class Dropper(BasicPipeFile):
        ...     config = dict(without=r'[a-zA-Z0-9]+', basename=r'[a-zA-Z0-9]+')
        ...     drop=('base',)
+       ...
        >>> d = Dropper()
        >>> d.get()
        >>> # New subclasses will drop the 'base' field as well
@@ -161,6 +167,7 @@ Usage
        >>> class Compound(BasicPipeFile):
        ...     config=dict(first=r'\d+', second=r'[a-zA-Z]+')
        ...     join=dict(base=('first', 'second'))
+       ...
        >>> c = Compound()
        >>> c.get()  # we see the original field 'base'
        >>> c.get(first=50, second='abc')  # providing each field to join will work
@@ -169,6 +176,7 @@ Usage
        >>> c.get(first=200)
        >>> class CompoundByDash(Compound):
        ...     join_sep = '-'  # you can specify the string to join compounds
+       ...
        >>> c = CompoundByDash('101-dalmatians.1.png')
        >>> c.get(first=300)
 
@@ -187,6 +195,7 @@ Usage
        ...     def get_path_pattern_list(self):
        ...         # As an example we are returning the pattern list from the name object (base, extrafield)
        ...         return super().get_pattern_list()
+       ...
        >>> fp = FilePath()
        >>> fp.get()
        >>> # path attribute will vary depending on the OS

--- a/docs/source/Overview.rst
+++ b/docs/source/Overview.rst
@@ -227,6 +227,7 @@ Usage
        ...         result = super().get_pattern_list()
        ...         result.append('nameproperty')
        ...         return result
+       ...
        >>> pf = PropertyField()
        >>> pf.get()
        >>> pf.name = 'simple props staticvalue.1.abc'

--- a/docs/source/Overview.rst
+++ b/docs/source/Overview.rst
@@ -30,7 +30,6 @@ Usage
        >>> from naming import Name
        >>> class BasicName(Name):
        ...     config = dict(base=r'\w+')
-       ...
        >>> n = BasicName()
        >>> n.get()  # no name has been set on the object, convention is solved with {missing} fields
        >>> n.values
@@ -53,7 +52,6 @@ Usage
        >>> from naming import Pipe
        >>> class BasicPipe(Pipe):
        ...     config = dict(base=r'\w+')
-       ...
        >>> p = BasicPipe()
        >>> p.get()
        >>> p.get(version=10)
@@ -81,7 +79,6 @@ Usage
        >>> from naming import File
        >>> class BasicFile(File):
        ...     config = dict(base=r'\w+')
-       ...
        >>> f = BasicFile()
        >>> f.get()
        >>> f.get(suffix='png')
@@ -102,7 +99,6 @@ Usage
        >>> from naming import PipeFile
        >>> class BasicPipeFile(PipeFile):
        ...     config = dict(base=r'\w+')
-       ...
        >>> p = BasicPipeFile('wipfile.7.ext')
        >>> p.values
        >>> [p.get(index=x, output='render') for x in range(10)]
@@ -124,7 +120,6 @@ Usage
        ...                   user='[a-z]+',
        ...                   another='(constant)',
        ...                   last='[a-zA-Z0-9]+')
-       ...
        >>> pf = ProjectFile('project_data_name_2017_christianl_constant_iamlast.data.17.abc', sep='_')
        >>> pf.values
        >>> pf.nice_name  # no pipe & suffix fields
@@ -147,7 +142,6 @@ Usage
        >>> class Dropper(BasicPipeFile):
        ...     config = dict(without=r'[a-zA-Z0-9]+', basename=r'[a-zA-Z0-9]+')
        ...     drop=('base',)
-       ...
        >>> d = Dropper()
        >>> d.get()
        >>> # New subclasses will drop the 'base' field as well
@@ -167,7 +161,6 @@ Usage
        >>> class Compound(BasicPipeFile):
        ...     config=dict(first=r'\d+', second=r'[a-zA-Z]+')
        ...     join=dict(base=('first', 'second'))
-       ...
        >>> c = Compound()
        >>> c.get()  # we see the original field 'base'
        >>> c.get(first=50, second='abc')  # providing each field to join will work
@@ -176,7 +169,6 @@ Usage
        >>> c.get(first=200)
        >>> class CompoundByDash(Compound):
        ...     join_sep = '-'  # you can specify the string to join compounds
-       ...
        >>> c = CompoundByDash('101-dalmatians.1.png')
        >>> c.get(first=300)
 
@@ -195,7 +187,6 @@ Usage
        ...     def get_path_pattern_list(self):
        ...         # As an example we are returning the pattern list from the name object (base, extrafield)
        ...         return super().get_pattern_list()
-       ...
        >>> fp = FilePath()
        >>> fp.get()
        >>> # path attribute will vary depending on the OS

--- a/docs/source/_static/pyrepl_bootstrap.py
+++ b/docs/source/_static/pyrepl_bootstrap.py
@@ -1,0 +1,5 @@
+from naming import PipeFile
+
+
+class BasicPipeFile(PipeFile):
+    config = dict(base=r'\w+')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ extensions = [
     'sphinx_copybutton',
     'sphinx_togglebutton',
     'sphinx_toggleprompt',
+    'sphinx_pyrepl_web',
 ]
 
 # Offset to play well with copybutton

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,5 +23,5 @@ packages = find:
 [options.extras_require]
 # docs dependencies install:
 # conda install --channel conda-forge pygraphviz
-# python -m pip install sphinx myst-parser sphinx-toggleprompt sphinx-copybutton sphinx-togglebutton sphinx_autodoc_typehints sphinx_rtd_theme sphinx-pyrepl-web
-docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx_autodoc_typehints; sphinx_rtd_theme; sphinx-pyrepl-web
+# python -m pip install sphinx myst-parser sphinx-toggleprompt sphinx-copybutton sphinx-togglebutton sphinx_autodoc_typehints sphinx_rtd_theme "sphinx-pyrepl-web>=0.1.1"
+docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx_autodoc_typehints; sphinx_rtd_theme; sphinx-pyrepl-web>=0.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,4 @@ packages = find:
 # docs dependencies install:
 # conda install --channel conda-forge pygraphviz
 # python -m pip install sphinx myst-parser sphinx-toggleprompt sphinx-copybutton sphinx-togglebutton sphinx-hoverxref sphinx_autodoc_typehints sphinx_rtd_theme
-docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx-hoverxref; sphinx_autodoc_typehints; sphinx_rtd_theme
+docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx-hoverxref; sphinx_autodoc_typehints; sphinx_rtd_theme; sphinx-pyrepl-web


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates the nine doctest walkthrough sections in `Overview.rst` to live browser REPLs using [sphinx-pyrepl-web](https://pypi.org/project/sphinx-pyrepl-web/).

- Adds `sphinx-pyrepl-web` to the `docs` extra in `setup.cfg`
- Registers `sphinx_pyrepl_web` in `conf.py`
- Adds `_static/pyrepl_bootstrap.py` so extending-name examples can share `BasicPipeFile` across isolated REPL sessions
- Converts all Overview tutorial blocks to `.. py-repl::` directives with `:packages: naming` (input lines only; doctest output lines removed)
- Notes that paths render as `PosixPath` in the browser REPL

README and autodoc docstring examples remain static, per the minimal migration scope.

## Validation

- `python3 docs/source/build_docs.py` succeeds (Sphinx 9.1.0)
- `Overview.html` contains 9 `<py-repl>` elements with `replay-src` attributes
- All generated `_static/pyrepl/Overview-*.py` replay scripts compile cleanly

## Notes

Merged latest `develop` (RTD Python 3.14, hoverxref removal for Sphinx 9 compatibility) and resolved the `setup.cfg` conflict by keeping develop's dependency set plus `sphinx-pyrepl-web`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-762ed516-0245-4422-8279-c805ffccdf3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-762ed516-0245-4422-8279-c805ffccdf3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

