### PR TITLE
REPL in autodoc doctests

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,6 +49,7 @@ extensions = [
 # Offset to play well with copybutton
 toggleprompt_offset_right = 35
 togglebutton_hint = " "
+pyrepl_doctest_blocks = "autodoc"
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,5 +23,5 @@ packages = find:
 [options.extras_require]
 # docs dependencies install:
 # conda install --channel conda-forge pygraphviz
-# python -m pip install sphinx myst-parser sphinx-toggleprompt sphinx-copybutton sphinx-togglebutton sphinx_autodoc_typehints sphinx_rtd_theme "sphinx-pyrepl-web>=0.1.1"
-docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx_autodoc_typehints; sphinx_rtd_theme; sphinx-pyrepl-web>=0.1.1
+# python -m pip install sphinx myst-parser sphinx-toggleprompt sphinx-copybutton sphinx-togglebutton sphinx_autodoc_typehints sphinx_rtd_theme "sphinx-pyrepl-web @ git+https://github.com/chrizzFTD/sphinx-pyrepl-web.git@cursor/autodoc-doctest-repl-3c18"
+docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx_autodoc_typehints; sphinx_rtd_theme; sphinx-pyrepl-web @ git+https://github.com/chrizzFTD/sphinx-pyrepl-web.git@cursor/autodoc-doctest-repl-3c18

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,5 @@ classifiers =
 packages = find:
 
 [options.extras_require]
-# docs dependencies install:
-# conda install --channel conda-forge pygraphviz
-# python -m pip install sphinx myst-parser sphinx-toggleprompt sphinx-copybutton sphinx-togglebutton sphinx_autodoc_typehints sphinx_rtd_theme "sphinx-pyrepl-web @ git+https://github.com/chrizzFTD/sphinx-pyrepl-web.git@cursor/autodoc-doctest-repl-3c18"
-docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx_autodoc_typehints; sphinx_rtd_theme; sphinx-pyrepl-web @ git+https://github.com/chrizzFTD/sphinx-pyrepl-web.git@cursor/autodoc-doctest-repl-3c18
+# python -m pip install -e ".[docs]"
+docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx_autodoc_typehints; sphinx_rtd_theme; sphinx-pyrepl-web>=0.2.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Enable autodoc doctest conversion to REPL in code examples

## Changes

- Update sphinx-pyrepl-web>=0.2.0
- Set `pyrepl_doctest_blocks = "autodoc"`

## Related

- Upstream PR: https://github.com/chrizzFTD/sphinx-pyrepl-web/pull/12
- Branch: `cursor/autodoc-doctest-repl-3c18`


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0b2eaae-84b8-4588-ba92-ce6c9aa5ae7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0b2eaae-84b8-4588-ba92-ce6c9aa5ae7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

