### PR TITLE
Enable sphinx-pyrepl-web :project: for autodoc REPL wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ dist/
 build/
 naming.egg-info/
 docs/build/
+docs/_build/
+docs/source/_static/wheels/*.whl
 *.pyc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,7 @@ extensions = [
 toggleprompt_offset_right = 35
 togglebutton_hint = " "
 pyrepl_doctest_blocks = "autodoc"
+pyrepl_autodoc_packages = ":project:"
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
 }
@@ -146,7 +147,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,4 @@ packages = find:
 
 [options.extras_require]
 # python -m pip install -e ".[docs]"
-docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx_autodoc_typehints; sphinx_rtd_theme; sphinx-pyrepl-web @ git+https://github.com/chrizzFTD/sphinx-pyrepl-web@cursor/auto-project-wheel-1aac
+docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx_autodoc_typehints; sphinx_rtd_theme; sphinx-pyrepl-web>=0.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,4 @@ packages = find:
 
 [options.extras_require]
 # python -m pip install -e ".[docs]"
-docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx_autodoc_typehints; sphinx_rtd_theme; sphinx-pyrepl-web>=0.2.0
+docs = sphinx; myst-parser; sphinx-toggleprompt; sphinx-copybutton; sphinx-togglebutton; sphinx_autodoc_typehints; sphinx_rtd_theme; sphinx-pyrepl-web @ git+https://github.com/chrizzFTD/sphinx-pyrepl-web@cursor/auto-project-wheel-1aac


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adopts the `:project:` sentinel from [sphinx-pyrepl-web 0.4.0](https://github.com/chrizzFTD/sphinx-pyrepl-web/pull/25) so autodoc doctest REPLs on API pages install the **in-tree** `naming` wheel at doc-build time, rather than replaying without a package or pulling from PyPI.

## Changes

- **`docs/source/conf.py`**
  - `pyrepl_autodoc_packages = ":project:"` — extension builds/reuses `naming-*.whl` under `_static/wheels/`
  - `html_static_path = ["_static"]` — serves bootstrap scripts and built wheels
- **`setup.cfg`**
  - `sphinx-pyrepl-web>=0.4.0` (PyPI)
- **`.gitignore`**
  - Ignore generated wheels and local `docs/_build/` output

## What this enables

API reference pages (`Name`, `File`, `Pipe`, `PipeFile`) emit REPLs with:

```
packages="_static/wheels/naming-0.7.1-py3-none-any.whl"
```

RTD and local builds document the branch under test without bespoke `pip wheel` scripts or RTD `pre_build` hooks.

## Out of scope

- **Overview.rst** manual `.. py-repl::` blocks still use `:packages: naming` (PyPI). Consolidating or switching those is a follow-up.
- **No CI changes** — REPL behavior is validated manually in the browser.
- **Doctest hygiene** (e.g. `PosixPath` vs `WindowsPath`) — separate follow-up.

## Verified

- `pip install -e ".[docs]"` resolves `sphinx-pyrepl-web` 0.4.0 from PyPI
- `sphinx -b html docs/source docs/_build` succeeds
- Wheel created at `docs/source/_static/wheels/naming-0.7.1-py3-none-any.whl`
- API pages include `packages="_static/wheels/naming-0.7.1-py3-none-any.whl"`

## Manual verification

```bash
pip install -e ".[docs]"
python -m sphinx -b html docs/source docs/_build
python -m http.server --directory docs/_build
```

Open API pages and confirm REPLs load and replay doctests interactively.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f36d1-1c09-71f6-b85a-b0daea4128f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f36d1-1c09-71f6-b85a-b0daea4128f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

